### PR TITLE
fixed a NullPointerException on startup

### DIFF
--- a/src/main/java/amidst/Settings.java
+++ b/src/main/java/amidst/Settings.java
@@ -54,7 +54,7 @@ public class Settings {
 		showScale                  = new BooleanSetting(        preferences, "showScale",           true);
 		showDebug                  = new BooleanSetting(        preferences, "showDebug",           false);
 		updateToUnstable           = new BooleanSetting(        preferences, "updateToUnstable",    false);
-		lastProfile                = new StringSetting(         preferences, "profile",             null);
+		lastProfile                = new StringSetting(         preferences, "profile",             "");
 		worldType                  = new MultipleStringsSetting(preferences, "worldType",           WorldType.PROMPT_EACH_TIME, WorldType.getWorldTypeSettingAvailableValues());
 		biomeColorProfileSelection = new BiomeColorProfileSelection(BiomeColorProfile.getDefaultProfile());
 		// @formatter:on

--- a/src/main/java/amidst/gui/profileselect/ProfileSelectPanel.java
+++ b/src/main/java/amidst/gui/profileselect/ProfileSelectPanel.java
@@ -176,6 +176,11 @@ public class ProfileSelectPanel {
 	}
 
 	@CalledOnlyBy(AmidstThread.EDT)
+	public void selectFirst() {
+		select(0);
+	}
+
+	@CalledOnlyBy(AmidstThread.EDT)
 	public void select(String profileName) {
 		select(getIndex(profileName));
 	}

--- a/src/main/java/amidst/gui/profileselect/ProfileSelectWindow.java
+++ b/src/main/java/amidst/gui/profileselect/ProfileSelectWindow.java
@@ -131,8 +131,10 @@ public class ProfileSelectWindow {
 	@CalledOnlyBy(AmidstThread.EDT)
 	private void restoreSelection() {
 		String profileName = settings.lastProfile.get();
-		if (profileName != null) {
+		if (profileName != null && !profileName.isEmpty()) {
 			profileSelectPanel.select(profileName);
+		} else {
+			profileSelectPanel.selectFirst();
 		}
 	}
 

--- a/src/main/java/amidst/settings/MultipleStringsSetting.java
+++ b/src/main/java/amidst/settings/MultipleStringsSetting.java
@@ -3,10 +3,12 @@ package amidst.settings;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.prefs.Preferences;
 
 import javax.swing.JToggleButton.ToggleButtonModel;
 
+import amidst.documentation.NotNull;
 import amidst.documentation.ThreadSafe;
 
 @ThreadSafe
@@ -43,7 +45,7 @@ public class MultipleStringsSetting extends SettingBase<String> {
 	private final Iterable<SelectButtonModel> buttonModels;
 
 	public MultipleStringsSetting(Preferences preferences, String key,
-			String defaultValue, String[] values) {
+			@NotNull String defaultValue, String[] values) {
 		super(preferences, key);
 		this.buttonModels = createButtonModels(values);
 		restore(defaultValue);
@@ -53,6 +55,7 @@ public class MultipleStringsSetting extends SettingBase<String> {
 		List<SelectButtonModel> result = new ArrayList<SelectButtonModel>(
 				values.length);
 		for (String value : values) {
+			Objects.requireNonNull(value);
 			result.add(new SelectButtonModel(value));
 		}
 		return Collections.unmodifiableList(result);

--- a/src/main/java/amidst/settings/SettingBase.java
+++ b/src/main/java/amidst/settings/SettingBase.java
@@ -1,7 +1,9 @@
 package amidst.settings;
 
+import java.util.Objects;
 import java.util.prefs.Preferences;
 
+import amidst.documentation.NotNull;
 import amidst.documentation.ThreadSafe;
 
 @ThreadSafe
@@ -15,7 +17,8 @@ public abstract class SettingBase<T> implements Setting<T> {
 		this.key = key;
 	}
 
-	protected void restore(T defaultValue) {
+	protected void restore(@NotNull T defaultValue) {
+		Objects.requireNonNull(defaultValue);
 		set(getInitialValue(defaultValue));
 	}
 
@@ -30,12 +33,14 @@ public abstract class SettingBase<T> implements Setting<T> {
 	}
 
 	@Override
-	public synchronized void set(T value) {
+	public synchronized void set(@NotNull T value) {
+		Objects.requireNonNull(value);
 		this.value = value;
 		update(value);
 	}
 
-	protected abstract T getInitialValue(T defaultValue);
+	@NotNull
+	protected abstract T getInitialValue(@NotNull T defaultValue);
 
-	protected abstract void update(T value);
+	protected abstract void update(@NotNull T value);
 }

--- a/src/main/java/amidst/settings/StringSetting.java
+++ b/src/main/java/amidst/settings/StringSetting.java
@@ -2,12 +2,13 @@ package amidst.settings;
 
 import java.util.prefs.Preferences;
 
+import amidst.documentation.NotNull;
 import amidst.documentation.ThreadSafe;
 
 @ThreadSafe
 public class StringSetting extends SettingBase<String> {
 	public StringSetting(Preferences preferences, String key,
-			String defaultValue) {
+			@NotNull String defaultValue) {
 		super(preferences, key);
 		restore(defaultValue);
 	}


### PR DESCRIPTION
When Amidst is started without settings file, it creates a settings file with default values. One of the default values was null, which is not allowed as a value in a preference store. I changed it to use the empty String instead. I also added some checks to ensure this does not happen again.

    [crash] Amidst crashed!
    [crash] java.lang.NullPointerException
            at java.util.prefs.AbstractPreferences.put(AbstractPreferences.java:241)
            at amidst.settings.StringSetting.update(StringSetting.java:22)
            at amidst.settings.StringSetting.update(StringSetting.java:7)
            at amidst.settings.SettingBase.set(SettingBase.java:35)
            at amidst.settings.SettingBase.restore(SettingBase.java:19)
            at amidst.settings.StringSetting.<init>(StringSetting.java:12)
            at amidst.Settings.<init>(Settings.java:57)
            at amidst.Application.createSettings(Application.java:55)
            at amidst.Application.<init>(Application.java:40)
            at amidst.Amidst.doStartApplication(Amidst.java:94)
            at amidst.Amidst.access$100(Amidst.java:21)
            at amidst.Amidst$2.run(Amidst.java:86)
            at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:311)
            at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:756)
            at java.awt.EventQueue.access$500(EventQueue.java:97)
            at java.awt.EventQueue$3.run(EventQueue.java:709)
            at java.awt.EventQueue$3.run(EventQueue.java:703)
            at java.security.AccessController.doPrivileged(Native Method)
            at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:76)
            at java.awt.EventQueue.dispatchEvent(EventQueue.java:726)
            at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:201)
            at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
            at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
            at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
            at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
            at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)