### PR TITLE
made the message in the crash window uneditable

### DIFF
--- a/src/main/java/amidst/gui/crash/CrashWindow.java
+++ b/src/main/java/amidst/gui/crash/CrashWindow.java
@@ -48,6 +48,7 @@ public class CrashWindow {
 
 	private JTextArea createLogMessagesTextArea(String logMessages) {
 		JTextArea result = new JTextArea(logMessages);
+		result.setEditable(false);
 		result.setFont(new Font("arial", Font.PLAIN, 10));
 		return result;
 	}


### PR DESCRIPTION
This is to prevent accidental changes while copying the crash report.