### PR TITLE
generate update information only for stable releases

### DIFF
--- a/src/devtools/java/amidst/devtools/GenerateUpdateInformationJson.java
+++ b/src/devtools/java/amidst/devtools/GenerateUpdateInformationJson.java
@@ -15,6 +15,10 @@ public class GenerateUpdateInformationJson {
 	public static void main(String[] args) {
 		AmidstVersion version = AmidstVersion.from(ResourceLoader
 				.getProperties("/amidst/metadata.properties"));
+		if (version.isPreRelease()) {
+			throw new RuntimeException(
+					"Update information documents can only be created for stable releases (not a pre-release).");
+		}
 		UpdateInformationJson json = new UpdateInformationJson(
 				version.getMajor(), version.getMinor(), "", DOWNLOAD_URL);
 		System.out.println(GSON.toJson(json));


### PR DESCRIPTION
Ensures that update information documents are only generated for stable releases, meaning a release that is not a pre-release.