### PR TITLE
Dev tool generate recognised version list

### DIFF
--- a/src/devtools/java/amidst/devtools/GenerateRecognisedVersionList.java
+++ b/src/devtools/java/amidst/devtools/GenerateRecognisedVersionList.java
@@ -130,7 +130,7 @@ public class GenerateRecognisedVersionList {
 				magicString = RecognisedVersion
 						.generateMagicString(classLoader);
 				recognisedVersion = RecognisedVersion.from(magicString);
-				process(versionId, recognisedVersion);
+				process(versionId, recognisedVersion, magicString);
 			} catch (ClassNotFoundException | MalformedURLException
 					| NoClassDefFoundError e) {
 				e.printStackTrace();
@@ -143,10 +143,10 @@ public class GenerateRecognisedVersionList {
 		}
 	}
 
-	private void process(String versionId, RecognisedVersion recognisedVersion) {
+	private void process(String versionId, RecognisedVersion recognisedVersion,
+			String magicString) {
 		allRecognisedVersions.remove(recognisedVersion);
 		String knownVersionId = recognisedVersion.getName();
-		String magicString = recognisedVersion.getMagicString();
 		if (recognisedVersion.equals(RecognisedVersion.UNKNOWN)) {
 			unknownVersions.add(createEnumString(versionId, magicString));
 		} else if (!versionId.equals(knownVersionId)) {

--- a/src/devtools/java/amidst/devtools/GenerateRecognisedVersionList.java
+++ b/src/devtools/java/amidst/devtools/GenerateRecognisedVersionList.java
@@ -1,0 +1,206 @@
+package amidst.devtools;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URLClassLoader;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import amidst.devtools.settings.DevToolsSettings;
+import amidst.logging.Log;
+import amidst.mojangapi.file.FilenameFactory;
+import amidst.mojangapi.file.MojangApiParsingException;
+import amidst.mojangapi.file.directory.DotMinecraftDirectory;
+import amidst.mojangapi.file.directory.VersionDirectory;
+import amidst.mojangapi.file.json.JsonReader;
+import amidst.mojangapi.file.json.versionlist.VersionListEntryJson;
+import amidst.mojangapi.file.json.versionlist.VersionListJson;
+import amidst.mojangapi.minecraftinterface.RecognisedVersion;
+
+public class GenerateRecognisedVersionList {
+	private static final int MAX_LENGTH_MAGIC_STRING = 111;
+
+	public static void main(String[] args) throws IOException,
+			MojangApiParsingException {
+		VersionListJson versionList = JsonReader.readRemoteVersionList();
+		int maxVersionIdLength = 0;
+		for (VersionListEntryJson version : versionList.getVersions()) {
+			if (maxVersionIdLength < version.getId().length()) {
+				maxVersionIdLength = version.getId().length();
+			}
+		}
+		new GenerateRecognisedVersionList(
+				DevToolsSettings.INSTANCE.getMinecraftVersionsDirectory(),
+				DevToolsSettings.INSTANCE.getMinecraftLibrariesDirectory(),
+				versionList, maxVersionIdLength).generate();
+	}
+
+	private final String prefix;
+	private final File libraries;
+	private final VersionListJson versionList;
+	private final File versions;
+	private final DotMinecraftDirectory dotMinecraftDirectory;
+	private final List<String> knownVersions = new LinkedList<String>();
+	private final List<String> knownButIncorrectVersions = new LinkedList<String>();
+	private final List<String> unknownVersions = new LinkedList<String>();
+	private final List<String> versionsWithError = new LinkedList<String>();
+	private final List<String> magicStringCollisions = new LinkedList<String>();
+	private final List<String> versionsWithoutAMatch = new LinkedList<String>();
+	private final Map<String, String> magicStringToFirstMatch = new LinkedHashMap<String, String>();
+	private final List<RecognisedVersion> allRecognisedVersions = new LinkedList<RecognisedVersion>();
+	private final Map<String, String> output = new LinkedHashMap<String, String>();
+	private final int maxVersionIdLength;
+
+	public GenerateRecognisedVersionList(String prefix, String libraries,
+			VersionListJson versionList, int maxVersionIdLength) {
+		this.prefix = prefix;
+		this.maxVersionIdLength = maxVersionIdLength;
+		this.libraries = new File(libraries);
+		this.versionList = versionList;
+		this.versions = new File(prefix);
+		this.dotMinecraftDirectory = new DotMinecraftDirectory(null,
+				this.libraries);
+		this.allRecognisedVersions.addAll(Arrays.asList(RecognisedVersion
+				.values()));
+	}
+
+	public void generate() {
+		for (VersionListEntryJson version : versionList.getVersions()) {
+			process(version);
+		}
+		for (RecognisedVersion recognisedVersion : allRecognisedVersions) {
+			versionsWithoutAMatch.add(createEnumString(
+					recognisedVersion.getName(),
+					recognisedVersion.getMagicString()));
+		}
+		System.out.println();
+		System.out.println();
+		System.out.println();
+		print("============== Known Versions ===============", knownVersions);
+		print("======= Known But Incorrect Versions ========",
+				knownButIncorrectVersions);
+		print("======== Versions Without A Match ===========",
+				versionsWithoutAMatch);
+		print("============= Unknown Versions ==============", unknownVersions);
+		print("================== Output ===================", output.values());
+		print("========== Magic String Collisions ==========",
+				magicStringCollisions);
+		print("============ Versions With Error ============",
+				versionsWithError);
+		System.out.println();
+		System.out
+				.println("If any version are listed in the error section, this might be due to missing libraries.\n"
+						+ "Start the given minecraft version with the launcher.\n"
+						+ "This should download the missing libraries. Afterwards, try again.");
+		System.out.println();
+		System.out
+				.println("When copying the magic string from this output, make sure to escape all special characters.");
+		System.out.println();
+		System.out
+				.println("Versions without a match are probably removed from the launcher.");
+		System.out.println();
+		System.out
+				.println("You might have to reorder the output, e.g. when a security fix for an old version came out, after the snapshots for the next version started.");
+	}
+
+	private VersionDirectory createVersionDirectory(String versionId) {
+		File jar = FilenameFactory.getClientJarFile(versions, versionId);
+		File json = FilenameFactory.getClientJsonFile(versions, versionId);
+		return new VersionDirectory(dotMinecraftDirectory, versionId, jar, json);
+	}
+
+	private void process(VersionListEntryJson version) {
+		String versionId = version.getId();
+		RecognisedVersion recognisedVersion = RecognisedVersion.UNKNOWN;
+		String magicString = null;
+		if (version.tryDownloadClient(prefix)) {
+			try {
+				Log.i("version " + versionId);
+				VersionDirectory versionDirectory = createVersionDirectory(versionId);
+				URLClassLoader classLoader = versionDirectory
+						.createClassLoader();
+				magicString = RecognisedVersion
+						.generateMagicString(classLoader);
+				recognisedVersion = RecognisedVersion.from(magicString);
+				allRecognisedVersions.remove(recognisedVersion);
+				String name = recognisedVersion.getName();
+				if (recognisedVersion.equals(RecognisedVersion.UNKNOWN)) {
+					unknownVersions
+							.add(createEnumString(versionId, magicString));
+				} else if (!versionId.equals(name)) {
+					knownButIncorrectVersions.add(addPadding(versionId)
+							+ " is known as "
+							+ createEnumString(name, magicString));
+				} else {
+					knownVersions.add(createEnumString(versionId, magicString));
+				}
+				if (magicStringToFirstMatch.containsKey(magicString)) {
+					magicStringCollisions
+							.add(addPadding(magicStringToFirstMatch
+									.get(magicString))
+									+ " and "
+									+ addPadding(versionId)
+									+ " with magic string '"
+									+ magicString
+									+ "'");
+					output.put(magicString, output.get(magicString) + " "
+							+ addPadding(versionId));
+				} else {
+					magicStringToFirstMatch.put(magicString, versionId);
+					output.put(
+							magicString,
+							addPadding(
+									createEnumString(versionId, magicString),
+									MAX_LENGTH_MAGIC_STRING)
+									+ " // matches the versions "
+									+ addPadding(versionId));
+				}
+			} catch (Throwable e) {
+				e.printStackTrace();
+				versionsWithError.add(addPadding(versionId) + " as "
+						+ addPadding(recognisedVersion.getName())
+						+ " with magic string '" + magicString + "'");
+			}
+		} else {
+			versionsWithError.add(addPadding(versionId) + " as "
+					+ addPadding(recognisedVersion.getName())
+					+ " with magic string '" + magicString + "'");
+		}
+	}
+
+	private void print(String title, Iterable<String> lines) {
+		System.out.println(title);
+		for (String line : lines) {
+			System.out.println(line);
+		}
+		System.out.println();
+	}
+
+	private String createEnumString(String versionId, String magicString) {
+		return addPadding(createEnumName(versionId)) + "(\"" + magicString
+				+ "\"),";
+	}
+
+	private String createEnumName(String versionId) {
+		return "V" + versionId.replace(".", "_");
+	}
+
+	private String addPadding(String versionId) {
+		return addPadding(versionId, maxVersionIdLength);
+	}
+
+	private String addPadding(String string, int length) {
+		return string + getStringOfLength(' ', length - string.length());
+	}
+
+	private String getStringOfLength(char c, int length) {
+		String result = "";
+		for (int i = 0; i < length; i++) {
+			result += c;
+		}
+		return result;
+	}
+}

--- a/src/devtools/java/amidst/devtools/GenerateRecognisedVersionList.java
+++ b/src/devtools/java/amidst/devtools/GenerateRecognisedVersionList.java
@@ -72,9 +72,11 @@ public class GenerateRecognisedVersionList {
 			process(version);
 		}
 		for (RecognisedVersion recognisedVersion : allRecognisedVersions) {
-			versionsWithoutAMatch.add(createEnumString(
-					recognisedVersion.getName(),
-					recognisedVersion.getMagicString()));
+			if (!recognisedVersion.equals(RecognisedVersion.UNKNOWN)) {
+				versionsWithoutAMatch.add(createEnumString(
+						recognisedVersion.getName(),
+						recognisedVersion.getMagicString()));
+			}
 		}
 		System.out.println();
 		System.out.println();

--- a/src/devtools/java/amidst/devtools/settings/DevToolsSettings.java
+++ b/src/devtools/java/amidst/devtools/settings/DevToolsSettings.java
@@ -4,8 +4,13 @@ public enum DevToolsSettings {
 	INSTANCE;
 
 	private String minecraftVersionsDirectory = "/home/stefan/.minecraft/amidst-all-client-versions/";
+	private String minecraftLibrariesDirectory = "/home/stefan/.minecraft/libraries/";
 
 	public String getMinecraftVersionsDirectory() {
 		return minecraftVersionsDirectory;
+	}
+
+	public String getMinecraftLibrariesDirectory() {
+		return minecraftLibrariesDirectory;
 	}
 }

--- a/src/main/java/amidst/mojangapi/minecraftinterface/RecognisedVersion.java
+++ b/src/main/java/amidst/mojangapi/minecraftinterface/RecognisedVersion.java
@@ -73,9 +73,16 @@ public enum RecognisedVersion {
 	V1_8_1beta("[Bhwqpyrrviqswdbzdqurkhqrgviwbomnabjrxmafvoeacfer[J[Jaddmkbb"); // Had to rename from V1_8_1 - should it just be removed?
 	// @formatter:on
 
+	@NotNull
 	public static RecognisedVersion from(URLClassLoader classLoader)
 			throws ClassNotFoundException {
-		return from(getMainClassFields(classLoader));
+		return from(generateMagicString(classLoader));
+	}
+
+	@NotNull
+	public static String generateMagicString(URLClassLoader classLoader)
+			throws ClassNotFoundException {
+		return generateMagicString(getMainClassFields(classLoader));
 	}
 
 	@NotNull
@@ -91,11 +98,13 @@ public enum RecognisedVersion {
 		}
 	}
 
+	@NotNull
 	public static RecognisedVersion from(Field[] fields) {
 		return from(generateMagicString(fields));
 	}
 
-	private static String generateMagicString(Field[] fields) {
+	@NotNull
+	public static String generateMagicString(Field[] fields) {
 		String result = "";
 		for (Field field : fields) {
 			String typeString = field.getType().toString();

--- a/src/main/java/amidst/mojangapi/minecraftinterface/RecognisedVersion.java
+++ b/src/main/java/amidst/mojangapi/minecraftinterface/RecognisedVersion.java
@@ -20,62 +20,95 @@ public enum RecognisedVersion {
 	// TODO: Remove these versions before V1_0?
 	// TODO: stronghold reset on V1_9pre4?
 	UNKNOWN(null),
-	V15w44b("qtoombkapb[Llq;mn[J[[Jmj"),
-	V15w43c("qsoombkapb[Llq;mn[J[[Jmj"),
-	V15w31c("oxnvlnjt[Llg;lz[J[[Jlv"),
-	V1_8_8("orntlljs[Lle;lx[J[[Jlt"),
-	V1_8_3("osnulmjt[Llf;ly[J[[Jlu"),
-	V1_8_1("wduyrdnq[Lqu;sp[J[[Jsa"),
-	V1_8("wbuwrcnp[Lqt;sn[J[[Jry"),
-	V14w21b("tjseoylw[Loq;qd[J[[Jpo"),
-	V1_7_10("riqinckb[Lmt;oi[J[[Jns"),
-	V1_7_9("rhqhnbkb[Lms;oh[J[[Jnr"),
-	V14w02a("qrponkki[Lnb;lv[J[[J"),
-	V1_7_4("pzozmvjs[Lmm;lg[J[[J"),
-	V1_7_2("pvovmsjp[Lmj;ld[J[[J"),
-	V13w39a("npmp[Lkn;jh[J[J[J[J[J[[J"), // or 13w39b
-	V13w37b("ntmt[Lkm;jg[J[J[J[J[J[[J"), // or 13w38a
-	V13w37a("nsms[Lkl;jf[J[J[J[J[J[[J"),
-	V13w36b("nkmk[Lkd;hw[J[J[J[J[J[[J"),
-	V13w36a("nkmk[Lkd;hx[J[J[J[J[J[[J"),
-	V1_6_4("mvlv[Ljs;hn[J[J[J[J[J[[J"),
-	V1_6_2("mulu[Ljr;hm[J[J[J[J[J[[J"),
-	V1_6_1("msls[Ljp;hk[J[J[J[J[J[[J"),
-	V1_5_2("[Bbdzbdrbawemabdsbfybdvngngbeuawfbgeawvawvaxrawbbfqausbjgaycawwaraavybkcavwbjubkila"),
-	V1_5_1("[Bbeabdsbawemabdtbfzbdwngngbevawfbgfawvawvaxrawbbfrausbjhaycawwaraavybkdavwbjvbkila"),
-	V1_5_0("Invalid"), // TODO: This makes no sense? 1.5.0 is not on the version list!
-	V1_4_6("[Baywayoaaszleaypbavaysmdazratabbaatqatqaulaswbanarnbdzauwatraohastbevasrbenbezbdmbdjkh"), // Includes 1.4.7
-	V1_4_5("[Bayoaygaasrleayhbakaykmdazfassbapatjatjaueasobacarfbdoaupatkanzaslbekasjbecbenbdbbcykh"),
-	V1_4_2("[Baxgawyaarjkpawzayyaxclnaxxarkazcasbasbaswargaytaqabcbathascamuardbcxarbbcpbdabbobbljy"),
-	V1_3_2("[Batkatcaaofjbatdavbatgjwaubaogavfaovaovapnaocauwamxaxvapyaowajqanzayqanxayjaytaxkaxhik"),
-	V1_3_1("adb"),
-	V1_3pre("acl"),
-	V12w27a("acs"),
-	V12w26a("acl"),
-	V12w25a("acg"),
-	V12w24a("aca"),
-	V12w23b("acg"),
-	V12w22a("ace"),
-	V12w21b("aby"),
-	V12w21a("abm"),
-	V12w19a("aau"),
-	V1_2_4("[Bkivmaftxdlvqacqcwfcaawnlnlvpjclrckqdaiyxgplhusdakagi[J[Jalfqabv"), // Includes 1.2.5
-	V1_2_2("wl"),
-	V12w08a("wj"),
-	V12w07b("wd"),
-	V12w06a("wb"),
-	V12w05a("vy"),
-	V12w04a("vu"),
-	V12w03a("vj"),
-	V1_1("[Bjsudadrvqluhaarcqevyzmqmqugiokzcepgagqvsonhhrgahqfy[J[Jaitpdbo"),
-	V1_0("[Baesmmaijryafvdinqfdrzhabeabexexwadtnglkqdfagvkiahmhsadk[J[Jtkgkyu"),
-	V1_9pre6("uk"),
-	V1_9pre5("ug"),
-	V1_9pre4("uh"),
-	V1_9pre3("to"),
-	V1_9pre2("sv"),
-	V1_9pre1("sq"),
-	V1_8_1beta("[Bhwqpyrrviqswdbzdqurkhqrgviwbomnabjrxmafvoeacfer[J[Jaddmkbb");
+	V15w51b     ("quonmajzpa[Llp;mm[J[[Jmi"),                                                                       // matches the versions 15w51b       15w51a      
+	V15w50a     ("qtonmajzpa[Llp;mm[J[[Jmi"),                                                                       // matches the versions 15w50a       15w49b       15w47c      
+	V15w46a     ("qsonmajzpa[Llp;mm[J[[Jmi"),                                                                       // matches the versions 15w46a      
+	V15w45a     ("qtoombkapb[Llq;mn[J[[Jmj"),                                                                       // matches the versions 15w45a       15w44b      
+	V15w43c     ("qsoombkapb[Llq;mn[J[[Jmj"),                                                                       // matches the versions 15w43c      
+	V15w42a     ("qnojlzjzow[Llp;ml[J[[Jmh"),                                                                       // matches the versions 15w42a      
+	V15w41b     ("qmoilyjyov[Llo;mk[J[[Jmg"),                                                                       // matches the versions 15w41b      
+	V15w40b     ("qhoelujuor[Llk;mg[J[[Jmc"),                                                                       // matches the versions 15w40b       15w39c       15w38b       15w37a      
+	V15w36d     ("qgodltjuoq[Lll;mf[J[[Jmb"),                                                                       // matches the versions 15w36d      
+	V15w35e     ("qeoclsjuop[Llk;me[J[[Jma"),                                                                       // matches the versions 15w35e      
+	V15w34d     ("qdoblsjuoo[Lll;me[J[[Jma"),                                                                       // matches the versions 15w34d      
+	V15w33c     ("qanzlrjtom[Llk;md[J[[Jlz"),                                                                       // matches the versions 15w33c      
+	V15w32c     ("pmnvlnjt[Llg;lz[J[[Jlv"),                                                                         // matches the versions 15w32c      
+	V15w31c     ("oxnvlnjt[Llg;lz[J[[Jlv"),                                                                         // matches the versions 15w31c      
+	V1_8_9      ("orntlljs[Lle;lx[J[[Jlt"),                                                                         // matches the versions 1.8.9        1.8.8        1.8.7        1.8.6        1.8.5        1.8.4       
+	V1_8_3      ("osnulmjt[Llf;ly[J[[Jlu"),                                                                         // matches the versions 1.8.3        1.8.2       
+	V1_8_1      ("wduyrdnq[Lqu;sp[J[[Jsa"),                                                                         // matches the versions 1.8.1       
+	V1_8        ("wbuwrcnp[Lqt;sn[J[[Jry"),                                                                         // matches the versions 1.8         
+	V14w21b     ("tjseoylw[Loq;qd[J[[Jpo"),                                                                         // not generated
+	V1_7_10     ("riqinckb[Lmt;oi[J[[Jns"),                                                                         // matches the versions 1.7.10      
+	V1_7_9      ("rhqhnbkb[Lms;oh[J[[Jnr"),                                                                         // matches the versions 1.7.9       
+	V14w02a     ("qrponkki[Lnb;lv[J[[J"),                                                                           // not generated
+	V1_7_5      ("qfpfnbjy[Lms;lm[J[[J"),                                                                           // matches the versions 1.7.5       
+	V1_7_4      ("pzozmvjs[Lmm;lg[J[[J"),                                                                           // matches the versions 1.7.4       
+	V1_7_2      ("pvovmsjp[Lmj;ld[J[[J"),                                                                           // matches the versions 1.7.2       
+	V13w39a     ("npmp[Lkn;jh[J[J[J[J[J[[J"),                                                                       // not generated or 13w39b
+	V13w37b     ("ntmt[Lkm;jg[J[J[J[J[J[[J"),                                                                       // not generated or 13w38a
+	V13w37a     ("nsms[Lkl;jf[J[J[J[J[J[[J"),                                                                       // not generated
+	V13w36b     ("nkmk[Lkd;hw[J[J[J[J[J[[J"),                                                                       // not generated
+	V13w36a     ("nkmk[Lkd;hx[J[J[J[J[J[[J"),                                                                       // not generated
+	V1_6_4      ("mvlv[Ljs;hn[J[J[J[J[J[[J"),                                                                       // matches the versions 1.6.4       
+	V1_6_2      ("mulu[Ljr;hm[J[J[J[J[J[[J"),                                                                       // matches the versions 1.6.2       
+	V1_6_1      ("msls[Ljp;hk[J[J[J[J[J[[J"),                                                                       // matches the versions 1.6.1       
+	V1_5_2      ("[Bbdzbdrbawemabdsbfybdvngngbeuawfbgeawvawvaxrawbbfqausbjgaycawwaraavybkcavwbjubkila"),            // matches the versions 1.5.2       
+	V1_5_1      ("[Bbeabdsbawemabdtbfzbdwngngbevawfbgfawvawvaxrawbbfrausbjhaycawwaraavybkdavwbjvbkila"),            // matches the versions 1.5.1       
+	V1_4_7      ("[Baywayoaaszleaypbavaysmdazratabbaatqatqaulaswbanarnbdzauwatraohastbevasrbenbezbdmbdjkh"),        // matches the versions 1.4.7        1.4.6       
+	V1_4_5      ("[Bayoaygaasrleayhbakaykmdazfassbapatjatjaueasobacarfbdoaupatkanzaslbekasjbecbenbdbbcykh"),        // matches the versions 1.4.5        1.4.4       
+	V1_4_2      ("[Baxgawyaarjkpawzayyaxclnaxxarkazcasbasbaswargaytaqabcbathascamuardbcxarbbcpbdabbobbljy"),        // matches the versions 1.4.2       
+	V1_3_2      ("[Batkatcaaofjbatdavbatgjwaubaogavfaovaovapnaocauwamxaxvapyaowajqanzayqanxayjaytaxkaxhik"),        // matches the versions 1.3.2       
+	V1_3_1      ("[Batjatbaaoejaatcavaatfjvauaaofaveaouaouapmaobauvamwaxuapxaovajpanyaypanwayiaysaxjaxgij"),        // matches the versions 1.3.1       
+	V1_3pre     ("acl"),                                                                                            // not generated
+	V12w27a     ("acs"),                                                                                            // not generated
+	V12w26a     ("acl"),                                                                                            // not generated
+	V12w25a     ("acg"),                                                                                            // not generated
+	V12w24a     ("aca"),                                                                                            // not generated
+	V12w23b     ("acg"),                                                                                            // not generated
+	V12w22a     ("ace"),                                                                                            // not generated
+	V12w21b     ("aby"),                                                                                            // not generated
+	V12w21a     ("abm"),                                                                                            // not generated
+	V12w19a     ("aau"),                                                                                            // not generated
+	V1_2_5      ("[Bkivmaftxdlvqacqcwfcaawnlnlvpjclrckqdaiyxgplhusdakagi[J[Jalfqabv"),                              // matches the versions 1.2.5        1.2.4       
+	V1_2_3      ("[Bkfviafowzlvmaclcueyaarninivlizlocipzaisxcphhrrzajugf[J[Jakzpwbt"),                              // matches the versions 1.2.3        1.2.2        1.2.1       
+	V12w08a     ("wj"),                                                                                             // not generated
+	V12w07b     ("wd"),                                                                                             // not generated
+	V12w06a     ("wb"),                                                                                             // not generated
+	V12w05a     ("vy"),                                                                                             // not generated
+	V12w04a     ("vu"),                                                                                             // not generated
+	V12w03a     ("vj"),                                                                                             // not generated
+	V1_1        ("[Bjsudadrvqluhaarcqevyzmqmqugiokzcepgagqvsonhhrgahqfy[J[Jaitpdbo"),                               // matches the versions 1.1         
+	V1_0        ("[Baesmmaijryafvdinqfdrzhabeabexexwadtnglkqdfagvkiahmhsadk[J[Jtkgkyu"),                            // matches the versions 1.0         
+	V1_9pre6    ("uk"),                                                                                             // not generated
+	V1_9pre5    ("ug"),                                                                                             // not generated
+	V1_9pre4    ("uh"),                                                                                             // not generated
+	V1_9pre3    ("to"),                                                                                             // not generated
+	V1_9pre2    ("sv"),                                                                                             // not generated
+	V1_9pre1    ("sq"),                                                                                             // not generated
+	Vb1_8_1     ("[Bhwqpyrrviqswdbzdqurkhqrgviwbomnabjrxmafvoeacfer[J[Jaddmkbb"),                                   // matches the versions b1.8.1       b1.8        
+	Vb1_7_3     ("[Bobcxpyfdndclsdngrjisjdamkpxczvuuqfhvfkvyovyik[J[Jxivscg"),                                      // matches the versions b1.7.3       b1.7.2       b1.7        
+	Vb1_6_6     ("[Bnxcvpufbmdalodlgpjfsecymgptcxvmukffuxkryfvqih[J[Jwzvkce"),                                      // matches the versions b1.6.6       b1.6.5       b1.6.4       b1.6.3       b1.6.2       b1.6.1       b1.6        
+	Vb1_5_01    ("nfcpozetmcukwdfggiprfcslooycruntlextyjzxeurhv[J[Jvyulbz"),                                        // matches the versions b1.5_01      b1.5        
+	Vb1_4_01    ("lncdmxebichjmcsfkhooxcfkcmwcerqqvefrkisujsbgw[J[Jtervbo"),                                        // matches the versions b1.4_01     
+	Vb1_4       ("lncdmxebichjmcsfkhooxcfkcmwcerpqvefrkisujsagw[J[Jterubo"),                                        // matches the versions b1.4        
+	Vb1_3_01    ("kybymidthccizcnfbhfoicbjpmhbzqfdxquigtmrhgn[J[Jrbbk"),                                            // matches the versions b1.3_01     
+	Vb1_3b      ("kybymidthccizcnfbhfoicbjpmhbzqgdxqvigtnrign[J[Jrcbk"),                                            // matches the versions b1.3b       
+	Vb1_2_02    ("kbbvlmdnhbzcjesgsnhbyiwllbwpedrprhqsgqega[J[Jpybj"),                                              // matches the versions b1.2_02      b1.2_01      b1.2        
+	Vb1_1_02    ("jjboksddfbsccehgemjbrifkrbpobdhonhbqvoyfo[J[Joubc"),                                              // matches the versions b1.1_02      b1.1_01     
+	Vb1_0_2     ("jibokrddfbscceggdmibriekqbpoadhomhaquoxfn[J[Jotbc"),                                              // matches the versions b1.0.2       b1.0_01      b1.0        
+	Va1_2_6     ("ivbmkccyfbqbzeafulsbphukbbnnldcnxgqqgoiff[J[Joeba"),                                              // matches the versions a1.2.6      
+	Va1_2_5     ("iubmkbcxfbqbydzftlrbphtkabnnkdbnwgpqfohfe[J[Jodba"),                                              // matches the versions a1.2.5       a1.2.4_01   
+	Va1_2_3_04  ("iubmkbcxfbqbydzftlqbphtkabnnjdbnvgpqeogfe[J[Jocba"),                                              // matches the versions a1.2.3_04    a1.2.3_02    a1.2.3_01    a1.2.3      
+	Va1_2_2b    ("isbmjycwfbqbydyfrlnbphrjxbnngdansgnqbodfd[J[Jnzba"),                                              // matches the versions a1.2.2b      a1.2.2a     
+	Va1_2_1_01  ("imbkjrcudbobwdufmlgbnhmjqblmzcynlgiptnv[J[Jnray"),                                                // matches the versions a1.2.1_01    a1.2.1       a1.2.0_02    a1.2.0_01    a1.2.0      
+	Va1_1_2_01  ("hqbeircnebibqdleykdbhgriqbflucrmffrofmp[Jmlat"),                                                  // matches the versions a1.1.2_01    a1.1.2      
+	Va1_1_0     ("hqbeircnebibqdleykdbhgriqbflucrmffroemo[Jmlat"),                                                  // matches the versions a1.1.0      
+	Va1_0_17_04 ("hpbdiqcmebhbpdkexkbbggqipbeltcqmdfqobmm[Jmjar"),                                                  // matches the versions a1.0.17_04   a1.0.17_02  
+	Va1_0_16    ("hgazihcjebebmdferjtbdgiigbblkcnlvfinrmd[Jmbap"),                                                  // matches the versions a1.0.16     
+	Va1_0_15    ("hfazigcjebebmdferjsbdgiifbbljcnlufinqmc[Jmaap"),                                                  // matches the versions a1.0.15     
+	Va1_0_14    ("hcazidcjebebmdfeqjpbdghicbblfcnlpfhnmly[Jlwap"),                                                  // matches the versions a1.0.14     
+	Va1_0_11    ("haaziacjebebmddenjlbdgfhzbbkzcnljfenels[Jlqap");                                                  // matches the versions a1.0.11     
 	// @formatter:on
 
 	@NotNull

--- a/src/main/java/amidst/mojangapi/minecraftinterface/RecognisedVersion.java
+++ b/src/main/java/amidst/mojangapi/minecraftinterface/RecognisedVersion.java
@@ -14,12 +14,17 @@ import amidst.logging.Log;
 @Immutable
 public enum RecognisedVersion {
 	// @formatter:off
-	UNKNOWN(null), // Make sure this is the first entry, so it is always considered newer than all other versions, since an unknown version is most likely a new snapshot
+	// Make sure UNKNOWN is the first entry, so it is always considered newer than all other versions, since an unknown version is most likely a new snapshot.
+	// 1.8.4, 1.8.5, 1.8.6, 1.8.7, and 1.8.8 all have the same typeDump version ID. They are all security issue fixes.
+	// 1.8.3 and 1.8.2 have the same typeDump version ID - probably because 1.8.2 -> 1.8.3 was a fix for a server-side bug (https://mojang.com/2015/02/minecraft-1-8-2-is-now-available/)
+	// TODO: Remove these versions before V1_0?
+	// TODO: stronghold reset on V1_9pre4?
+	UNKNOWN(null),
 	V15w44b("qtoombkapb[Llq;mn[J[[Jmj"),
 	V15w43c("qsoombkapb[Llq;mn[J[[Jmj"),
 	V15w31c("oxnvlnjt[Llg;lz[J[[Jlv"),
-	V1_8_8("orntlljs[Lle;lx[J[[Jlt"), // 1.8.4, 1.8.5, 1.8.6, 1.8.7, and 1.8.8 all have the same typeDump version ID. They are all security issue fixes.
-	V1_8_3("osnulmjt[Llf;ly[J[[Jlu"), // 1.8.3 and 1.8.2 have the same typeDump version ID - probably because 1.8.2 -> 1.8.3 was a fix for a server-side bug (https://mojang.com/2015/02/minecraft-1-8-2-is-now-available/)
+	V1_8_8("orntlljs[Lle;lx[J[[Jlt"),
+	V1_8_3("osnulmjt[Llf;ly[J[[Jlu"),
 	V1_8_1("wduyrdnq[Lqu;sp[J[[Jsa"),
 	V1_8("wbuwrcnp[Lqt;sn[J[[Jry"),
 	V14w21b("tjseoylw[Loq;qd[J[[Jpo"),
@@ -64,13 +69,13 @@ public enum RecognisedVersion {
 	V12w03a("vj"),
 	V1_1("[Bjsudadrvqluhaarcqevyzmqmqugiokzcepgagqvsonhhrgahqfy[J[Jaitpdbo"),
 	V1_0("[Baesmmaijryafvdinqfdrzhabeabexexwadtnglkqdfagvkiahmhsadk[J[Jtkgkyu"),
-	V1_9pre6("uk"), // TODO: Remove these versions?
+	V1_9pre6("uk"),
 	V1_9pre5("ug"),
-	V1_9pre4("uh"),  //TODO stronghold reset??
+	V1_9pre4("uh"),
 	V1_9pre3("to"),
 	V1_9pre2("sv"),
 	V1_9pre1("sq"),
-	V1_8_1beta("[Bhwqpyrrviqswdbzdqurkhqrgviwbomnabjrxmafvoeacfer[J[Jaddmkbb"); // Had to rename from V1_8_1 - should it just be removed?
+	V1_8_1beta("[Bhwqpyrrviqswdbzdqurkhqrgviwbomnabjrxmafvoeacfer[J[Jaddmkbb");
 	// @formatter:on
 
 	@NotNull

--- a/src/main/java/amidst/mojangapi/world/versionfeatures/DefaultVersionFeatures.java
+++ b/src/main/java/amidst/mojangapi/world/versionfeatures/DefaultVersionFeatures.java
@@ -93,7 +93,7 @@ public enum DefaultVersionFeatures {
 				.init(
 						// this is for the enable all layers function
 						getValidBiomesForStrongholdSinceV13w36a()
-				).since(RecognisedVersion.V1_8_1beta,
+				).since(RecognisedVersion.Vb1_8_1,
 						Biome.desert,
 						Biome.forest,
 						Biome.extremeHills,


### PR DESCRIPTION
* added a devtool to generate the entries of the enum RecognisedVersion
* replaced the existing enum entries by the generated list
* kept the entries that were included in the enum, but that are already removed from the launcher (and thus not generated)