### PR TITLE
Bug fixing

### DIFF
--- a/src/main/java/amidst/Amidst.java
+++ b/src/main/java/amidst/Amidst.java
@@ -2,6 +2,7 @@ package amidst;
 
 import java.io.File;
 
+import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
@@ -17,6 +18,7 @@ import amidst.documentation.NotThreadSafe;
 import amidst.gui.crash.CrashWindow;
 import amidst.logging.FileLogger;
 import amidst.logging.Log;
+import amidst.mojangapi.file.DotMinecraftDirectoryNotFoundException;
 
 @NotThreadSafe
 public class Amidst {
@@ -124,6 +126,15 @@ public class Amidst {
 			AmidstMetaData metadata) {
 		try {
 			new Application(parameters, metadata).run();
+		} catch (DotMinecraftDirectoryNotFoundException e) {
+			Log.w(e.getMessage());
+			e.printStackTrace();
+			JOptionPane
+					.showMessageDialog(
+							null,
+							"Amidst is not able to find your '.minecraft' directory, but it requires a working Minecraft installation.",
+							"Please install Minecraft",
+							JOptionPane.ERROR_MESSAGE);
 		} catch (Exception e) {
 			handleCrash(e, "Amidst crashed!");
 		}

--- a/src/main/java/amidst/Application.java
+++ b/src/main/java/amidst/Application.java
@@ -1,6 +1,5 @@
 package amidst;
 
-import java.io.FileNotFoundException;
 import java.util.prefs.Preferences;
 
 import amidst.documentation.AmidstThread;
@@ -14,6 +13,7 @@ import amidst.gui.main.viewer.ViewerFacadeBuilder;
 import amidst.gui.profileselect.ProfileSelectWindow;
 import amidst.mojangapi.MojangApi;
 import amidst.mojangapi.MojangApiBuilder;
+import amidst.mojangapi.file.DotMinecraftDirectoryNotFoundException;
 import amidst.mojangapi.minecraftinterface.local.LocalMinecraftInterfaceCreationException;
 import amidst.mojangapi.world.SeedHistoryLogger;
 import amidst.mojangapi.world.WorldBuilder;
@@ -36,7 +36,7 @@ public class Application {
 
 	@CalledOnlyBy(AmidstThread.EDT)
 	public Application(CommandLineParameters parameters, AmidstMetaData metadata)
-			throws FileNotFoundException,
+			throws DotMinecraftDirectoryNotFoundException,
 			LocalMinecraftInterfaceCreationException {
 		this.parameters = parameters;
 		this.metadata = metadata;
@@ -53,7 +53,8 @@ public class Application {
 	}
 
 	@CalledOnlyBy(AmidstThread.EDT)
-	private MojangApi createMojangApi() throws FileNotFoundException,
+	private MojangApi createMojangApi()
+			throws DotMinecraftDirectoryNotFoundException,
 			LocalMinecraftInterfaceCreationException {
 		return new MojangApiBuilder(new WorldBuilder(
 				new PlayerInformationCache(),

--- a/src/main/java/amidst/gui/main/Actions.java
+++ b/src/main/java/amidst/gui/main/Actions.java
@@ -211,7 +211,8 @@ public class Actions {
 		ViewerFacade viewerFacade = this.viewerFacade.get();
 		if (viewerFacade != null) {
 			BufferedImage image = viewerFacade.createCaptureImage();
-			File file = mainWindow.askForCaptureImageSaveFile();
+			File file = mainWindow.askForCaptureImageSaveFile("screenshot-"
+					+ viewerFacade.getWorldSeed().getLong() + ".png");
 			if (file != null) {
 				saveImageToFile(image, file);
 			}

--- a/src/main/java/amidst/gui/main/MainWindow.java
+++ b/src/main/java/amidst/gui/main/MainWindow.java
@@ -78,7 +78,8 @@ public class MainWindow {
 	private JFrame createFrame() {
 		JFrame frame = new JFrame();
 		frame.setTitle(createVersionString(mojangApi.getVersionId(),
-				mojangApi.getRecognisedVersionName()));
+				mojangApi.getRecognisedVersionName(),
+				mojangApi.getProfileName()));
 		frame.setSize(1000, 800);
 		frame.setIconImage(metadata.getIcon());
 		return frame;
@@ -86,9 +87,10 @@ public class MainWindow {
 
 	@CalledOnlyBy(AmidstThread.EDT)
 	private String createVersionString(String versionId,
-			String recognisedVersionName) {
+			String recognisedVersionName, String profileName) {
 		return metadata.getVersion().createLongVersionString()
-				+ " - Minecraft Version " + versionId + " ("
+				+ " - Selected Profile: " + profileName
+				+ " - Minecraft Version " + versionId + " (recognised: "
 				+ recognisedVersionName + ")";
 	}
 

--- a/src/main/java/amidst/gui/main/MainWindow.java
+++ b/src/main/java/amidst/gui/main/MainWindow.java
@@ -215,7 +215,7 @@ public class MainWindow {
 
 	@CalledOnlyBy(AmidstThread.EDT)
 	public File askForMinecraftWorldFile() {
-		return getSelectedFileOrNull(createMinecraftWorldFileChooser());
+		return showOpenDialogAndGetSelectedFileOrNull(createMinecraftWorldFileChooser());
 	}
 
 	@CalledOnlyBy(AmidstThread.EDT)
@@ -230,21 +230,32 @@ public class MainWindow {
 	}
 
 	@CalledOnlyBy(AmidstThread.EDT)
-	public File askForCaptureImageSaveFile() {
-		return getSelectedFileOrNull(createCaptureImageSaveFileChooser());
+	private File showOpenDialogAndGetSelectedFileOrNull(JFileChooser fileChooser) {
+		if (fileChooser.showOpenDialog(frame) == JFileChooser.APPROVE_OPTION) {
+			return fileChooser.getSelectedFile();
+		} else {
+			return null;
+		}
 	}
 
 	@CalledOnlyBy(AmidstThread.EDT)
-	private JFileChooser createCaptureImageSaveFileChooser() {
+	public File askForCaptureImageSaveFile(String suggestedFilename) {
+		return showSaveDialogAndGetSelectedFileOrNull(createCaptureImageSaveFileChooser(suggestedFilename));
+	}
+
+	@CalledOnlyBy(AmidstThread.EDT)
+	private JFileChooser createCaptureImageSaveFileChooser(
+			String suggestedFilename) {
 		JFileChooser result = new JFileChooser();
 		result.setFileFilter(new PNGFileFilter());
 		result.setAcceptAllFileFilterUsed(false);
+		result.setSelectedFile(new File(suggestedFilename));
 		return result;
 	}
 
 	@CalledOnlyBy(AmidstThread.EDT)
-	private File getSelectedFileOrNull(JFileChooser fileChooser) {
-		if (fileChooser.showOpenDialog(frame) == JFileChooser.APPROVE_OPTION) {
+	private File showSaveDialogAndGetSelectedFileOrNull(JFileChooser fileChooser) {
+		if (fileChooser.showSaveDialog(frame) == JFileChooser.APPROVE_OPTION) {
 			return fileChooser.getSelectedFile();
 		} else {
 			return null;

--- a/src/main/java/amidst/gui/main/menu/LayersMenu.java
+++ b/src/main/java/amidst/gui/main/menu/LayersMenu.java
@@ -64,14 +64,14 @@ public class LayersMenu {
 	@CalledOnlyBy(AmidstThread.EDT)
 	private void createDimensionLayers(Dimension dimension) {
 		if (viewerFacade.hasLayer(LayerIds.END_ISLANDS)) {
-			createGrid();
+			createAllDimensions();
 			menu.addSeparator();
 			createOverworldAndEndLayers(dimension);
 			createEnableAllLayersIfNecessary();
 		} else if (!dimension.equals(Dimension.OVERWORLD)) {
 			dimensionSetting.set(Dimension.OVERWORLD);
 		} else {
-			createGrid();
+			createAllDimensions();
 			menu.addSeparator();
 			createOverworldLayers(dimension);
 			createEnableAllLayersIfNecessary();
@@ -94,7 +94,7 @@ public class LayersMenu {
 		createOverworldLayers(dimension);
 		menu.addSeparator();
 		Menus.radio(   menu, dimensionSetting, group,     Dimension.END,                                            "ctrl shift 2");
-		endLayer(      settings.showEndCities,            "End City Icons",         getIcon("end_city.png"),        "ctrl 0", dimension, LayerIds.END_CITY);
+		endLayer(      settings.showEndCities,            "End City Icons",         getIcon("end_city.png"),        "ctrl 9", dimension, LayerIds.END_CITY);
 		// @formatter:on
 	}
 
@@ -104,19 +104,19 @@ public class LayersMenu {
 		overworldLayer(settings.showSlimeChunks,          "Slime Chunks",           getIcon("slime.png"),           "ctrl 1", dimension, LayerIds.SLIME);
 		overworldLayer(settings.showSpawn,                "Spawn Location Icon",    getIcon("spawn.png"),           "ctrl 2", dimension, LayerIds.SPAWN);
 		overworldLayer(settings.showStrongholds,          "Stronghold Icons",       getIcon("stronghold.png"),      "ctrl 3", dimension, LayerIds.STRONGHOLD);
-		overworldLayer(settings.showPlayers,              "Player Icons",           getIcon("player.png"),          "ctrl 4", dimension, LayerIds.PLAYER);
-		overworldLayer(settings.showVillages,             "Village Icons",          getIcon("village.png"),         "ctrl 5", dimension, LayerIds.VILLAGE);
-		overworldLayer(settings.showTemples,              "Temple/Witch Hut Icons", getIcon("desert.png"),          "ctrl 6", dimension, LayerIds.TEMPLE);
-		overworldLayer(settings.showMineshafts,           "Mineshaft Icons",        getIcon("mineshaft.png"),       "ctrl 7", dimension, LayerIds.MINESHAFT);
-		overworldLayer(settings.showOceanMonuments,       "Ocean Monument Icons",   getIcon("ocean_monument.png"),  "ctrl 8", dimension, LayerIds.OCEAN_MONUMENT);
-		overworldLayer(settings.showNetherFortresses,     "Nether Fortress Icons",  getIcon("nether_fortress.png"), "ctrl 9", dimension, LayerIds.NETHER_FORTRESS);
+		overworldLayer(settings.showVillages,             "Village Icons",          getIcon("village.png"),         "ctrl 4", dimension, LayerIds.VILLAGE);
+		overworldLayer(settings.showTemples,              "Temple/Witch Hut Icons", getIcon("desert.png"),          "ctrl 5", dimension, LayerIds.TEMPLE);
+		overworldLayer(settings.showMineshafts,           "Mineshaft Icons",        getIcon("mineshaft.png"),       "ctrl 6", dimension, LayerIds.MINESHAFT);
+		overworldLayer(settings.showOceanMonuments,       "Ocean Monument Icons",   getIcon("ocean_monument.png"),  "ctrl 7", dimension, LayerIds.OCEAN_MONUMENT);
+		overworldLayer(settings.showNetherFortresses,     "Nether Fortress Icons",  getIcon("nether_fortress.png"), "ctrl 8", dimension, LayerIds.NETHER_FORTRESS);
 		// @formatter:on
 	}
 
 	@CalledOnlyBy(AmidstThread.EDT)
-	private void createGrid() {
+	private void createAllDimensions() {
 		// @formatter:off
 		Menus.checkbox(menu, settings.showGrid,           "Grid",                   getIcon("grid.png"),            "ctrl G");
+		Menus.checkbox(menu, settings.showPlayers,        "Player Icons",           getIcon("player.png"),          "ctrl P");
 		// @formatter:on
 	}
 

--- a/src/main/java/amidst/gui/profileselect/LocalProfileComponent.java
+++ b/src/main/java/amidst/gui/profileselect/LocalProfileComponent.java
@@ -79,7 +79,8 @@ public class LocalProfileComponent extends ProfileComponent {
 			@Override
 			protected void main()
 					throws LocalMinecraftInterfaceCreationException {
-				mojangApi.set(profileDirectory, versionDirectory);
+				mojangApi.set(profile.getName(), profileDirectory,
+						versionDirectory);
 			}
 
 			@Override

--- a/src/main/java/amidst/gui/profileselect/ProfileSelectWindow.java
+++ b/src/main/java/amidst/gui/profileselect/ProfileSelectWindow.java
@@ -12,8 +12,8 @@ import javax.swing.SwingConstants;
 
 import net.miginfocom.swing.MigLayout;
 import amidst.AmidstMetaData;
-import amidst.Application;
 import amidst.AmidstSettings;
+import amidst.Application;
 import amidst.documentation.AmidstThread;
 import amidst.documentation.CalledOnlyBy;
 import amidst.documentation.NotThreadSafe;

--- a/src/main/java/amidst/mojangapi/MojangApi.java
+++ b/src/main/java/amidst/mojangapi/MojangApi.java
@@ -26,6 +26,7 @@ import amidst.mojangapi.world.WorldType;
 @ThreadSafe
 public class MojangApi {
 	private static final String UNKNOWN_VERSION_ID = "unknown";
+	private static final String UNKNOWN_PROFILE_NAME = "unknown";
 
 	private final WorldBuilder worldBuilder;
 	private final DotMinecraftDirectory dotMinecraftDirectory;
@@ -34,6 +35,7 @@ public class MojangApi {
 	private volatile ProfileDirectory profileDirectory;
 	private volatile VersionDirectory versionDirectory;
 	private volatile MinecraftInterface minecraftInterface;
+	private volatile String profileName;
 
 	public MojangApi(WorldBuilder worldBuilder,
 			DotMinecraftDirectory dotMinecraftDirectory) {
@@ -60,9 +62,10 @@ public class MojangApi {
 		return versionList;
 	}
 
-	public void set(ProfileDirectory profileDirectory,
+	public void set(String profileName, ProfileDirectory profileDirectory,
 			VersionDirectory versionDirectory)
 			throws LocalMinecraftInterfaceCreationException {
+		this.profileName = profileName;
 		this.profileDirectory = profileDirectory;
 		this.versionDirectory = versionDirectory;
 		if (versionDirectory != null) {
@@ -157,6 +160,14 @@ public class MojangApi {
 			return minecraftInterface.getRecognisedVersion().getName();
 		} else {
 			return RecognisedVersion.UNKNOWN.getName();
+		}
+	}
+
+	public String getProfileName() {
+		if (profileName != null) {
+			return profileName;
+		} else {
+			return UNKNOWN_PROFILE_NAME;
 		}
 	}
 }

--- a/src/main/java/amidst/mojangapi/MojangApiBuilder.java
+++ b/src/main/java/amidst/mojangapi/MojangApiBuilder.java
@@ -40,7 +40,7 @@ public class MojangApiBuilder {
 							+ dotMinecraftDirectory.getLibraries() + "'");
 		}
 		MojangApi result = new MojangApi(worldBuilder, dotMinecraftDirectory);
-		result.set(null, createVersionDirectory(result));
+		result.set(null, null, createVersionDirectory(result));
 		return result;
 	}
 

--- a/src/main/java/amidst/mojangapi/MojangApiBuilder.java
+++ b/src/main/java/amidst/mojangapi/MojangApiBuilder.java
@@ -1,13 +1,13 @@
 package amidst.mojangapi;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 
 import amidst.CommandLineParameters;
 import amidst.documentation.Immutable;
 import amidst.documentation.NotNull;
 import amidst.logging.Log;
 import amidst.mojangapi.file.DotMinecraftDirectoryFinder;
+import amidst.mojangapi.file.DotMinecraftDirectoryNotFoundException;
 import amidst.mojangapi.file.directory.DotMinecraftDirectory;
 import amidst.mojangapi.file.directory.VersionDirectory;
 import amidst.mojangapi.minecraftinterface.local.LocalMinecraftInterfaceCreationException;
@@ -25,7 +25,7 @@ public class MojangApiBuilder {
 	}
 
 	@NotNull
-	public MojangApi construct() throws FileNotFoundException,
+	public MojangApi construct() throws DotMinecraftDirectoryNotFoundException,
 			LocalMinecraftInterfaceCreationException {
 		DotMinecraftDirectory dotMinecraftDirectory = createDotMinecraftDirectory();
 		if (dotMinecraftDirectory.isValid()) {
@@ -33,7 +33,7 @@ public class MojangApiBuilder {
 					+ dotMinecraftDirectory.getRoot() + "', libraries: '"
 					+ dotMinecraftDirectory.getLibraries() + "'");
 		} else {
-			throw new FileNotFoundException(
+			throw new DotMinecraftDirectoryNotFoundException(
 					"invalid '.minecraft' directory at: '"
 							+ dotMinecraftDirectory.getRoot()
 							+ "', libraries: '"

--- a/src/main/java/amidst/mojangapi/file/DotMinecraftDirectoryNotFoundException.java
+++ b/src/main/java/amidst/mojangapi/file/DotMinecraftDirectoryNotFoundException.java
@@ -1,0 +1,11 @@
+package amidst.mojangapi.file;
+
+import java.io.FileNotFoundException;
+
+@SuppressWarnings("serial")
+public class DotMinecraftDirectoryNotFoundException extends
+		FileNotFoundException {
+	public DotMinecraftDirectoryNotFoundException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/amidst/mojangapi/file/json/launcherprofiles/LauncherProfileJson.java
+++ b/src/main/java/amidst/mojangapi/file/json/launcherprofiles/LauncherProfileJson.java
@@ -16,7 +16,18 @@ import amidst.mojangapi.file.json.versionlist.VersionListJson;
 
 @Immutable
 public class LauncherProfileJson {
-	private volatile String name;
+	/**
+	 * Some Minecraft installations have a profile with the key "(Default)" and
+	 * no properties in the actual profile object. The JSON looks like this:
+	 * 
+	 * "(Default)": {},
+	 * 
+	 * This profile has the name null. Also, it cannot be deleted from the
+	 * launcher. I guess this is a bug in the minecraft launcher. However, the
+	 * minecraft launcher displays it with an empty string as name and it uses
+	 * the latest stable release for it, so we do the same.
+	 */
+	private volatile String name = "";
 	private volatile String lastVersionId;
 	private volatile String gameDir;
 	private volatile List<ReleaseType> allowedReleaseTypes = Arrays

--- a/src/main/java/amidst/mojangapi/world/WorldBuilder.java
+++ b/src/main/java/amidst/mojangapi/world/WorldBuilder.java
@@ -95,37 +95,43 @@ public class WorldBuilder {
 						4,
 						new VillageLocationChecker(seed, biomeDataOracle, versionFeatures.getValidBiomesForStructure_Village()),
 						new ImmutableWorldIconTypeProvider(DefaultWorldIconTypes.VILLAGE),
-						Dimension.OVERWORLD
+						Dimension.OVERWORLD,
+						false
 				), new StructureProducer<Void>(
 						Resolution.CHUNK,
 						8,
 						new TempleLocationChecker(seed, biomeDataOracle, versionFeatures.getValidBiomesAtMiddleOfChunk_Temple()),
 						new TempleWorldIconTypeProvider(biomeDataOracle),
-						Dimension.OVERWORLD
+						Dimension.OVERWORLD,
+						false
 				), new StructureProducer<Void>(
 						Resolution.CHUNK,
 						8,
 						versionFeatures.getMineshaftAlgorithmFactory().apply(seed),
 						new ImmutableWorldIconTypeProvider(DefaultWorldIconTypes.MINESHAFT),
-						Dimension.OVERWORLD
+						Dimension.OVERWORLD,
+						false
 				), new StructureProducer<Void>(
 						Resolution.CHUNK,
 						8,
 						new OceanMonumentLocationChecker(seed, biomeDataOracle, versionFeatures.getValidBiomesAtMiddleOfChunk_OceanMonument(), versionFeatures.getValidBiomesForStructure_OceanMonument()),
 						new ImmutableWorldIconTypeProvider(DefaultWorldIconTypes.OCEAN_MONUMENT),
-						Dimension.OVERWORLD
+						Dimension.OVERWORLD,
+						false
 				), new StructureProducer<Void>(
 						Resolution.NETHER_CHUNK,
 						88,
 						new NetherFortressAlgorithm(seed),
 						new ImmutableWorldIconTypeProvider(DefaultWorldIconTypes.NETHER_FORTRESS),
-						Dimension.NETHER
+						Dimension.NETHER,
+						false
 				), new StructureProducer<List<EndIsland>>(
 						Resolution.CHUNK,
 						8,
 						new EndCityLocationChecker(seed),
 						new EndCityWorldIconTypeProvider(),
-						Dimension.END
+						Dimension.END,
+						false
 				)
 		);
 		// @formatter:on

--- a/src/main/java/amidst/mojangapi/world/icon/WorldIcon.java
+++ b/src/main/java/amidst/mojangapi/world/icon/WorldIcon.java
@@ -13,13 +13,15 @@ public class WorldIcon {
 	private final String name;
 	private final BufferedImage image;
 	private final Dimension dimension;
+	private final boolean displayDimension;
 
 	public WorldIcon(CoordinatesInWorld coordinates, String name,
-			BufferedImage image, Dimension dimension) {
+			BufferedImage image, Dimension dimension, boolean displayDimension) {
 		this.coordinates = coordinates;
 		this.name = name;
 		this.image = image;
 		this.dimension = dimension;
+		this.displayDimension = displayDimension;
 	}
 
 	public CoordinatesInWorld getCoordinates() {
@@ -44,9 +46,11 @@ public class WorldIcon {
 			return name + " in the " + dimension.getName() + " "
 					+ coordinates.toString(dimension.getResolution()) + " -> "
 					+ coordinates.toString() + " in the Overworld";
-		} else {
+		} else if (displayDimension) {
 			return name + " in the " + dimension.getName() + " "
 					+ coordinates.toString();
+		} else {
+			return name + " " + coordinates.toString();
 		}
 	}
 }

--- a/src/main/java/amidst/mojangapi/world/icon/producer/PlayerProducer.java
+++ b/src/main/java/amidst/mojangapi/world/icon/producer/PlayerProducer.java
@@ -24,7 +24,7 @@ public class PlayerProducer extends CachedWorldIconProducer {
 			PlayerCoordinates coordinates = player.getPlayerCoordinates();
 			result.add(new WorldIcon(coordinates.getCoordinatesInWorld(),
 					player.getPlayerName(), player.getHead(), coordinates
-							.getDimension()));
+							.getDimension(), true));
 		}
 		return result;
 	}

--- a/src/main/java/amidst/mojangapi/world/icon/producer/SpawnProducer.java
+++ b/src/main/java/amidst/mojangapi/world/icon/producer/SpawnProducer.java
@@ -46,7 +46,8 @@ public class SpawnProducer extends CachedWorldIconProducer {
 	private WorldIcon createWorldIcon(CoordinatesInWorld coordinates) {
 		return new WorldIcon(coordinates,
 				DefaultWorldIconTypes.SPAWN.getName(),
-				DefaultWorldIconTypes.SPAWN.getImage(), Dimension.OVERWORLD);
+				DefaultWorldIconTypes.SPAWN.getImage(), Dimension.OVERWORLD,
+				false);
 	}
 
 	private CoordinatesInWorld getSpawnCenterInWorldCoordinates() {

--- a/src/main/java/amidst/mojangapi/world/icon/producer/StrongholdProducer.java
+++ b/src/main/java/amidst/mojangapi/world/icon/producer/StrongholdProducer.java
@@ -99,7 +99,7 @@ public class StrongholdProducer extends CachedWorldIconProducer {
 		return new WorldIcon(coordinates,
 				DefaultWorldIconTypes.STRONGHOLD.getName(),
 				DefaultWorldIconTypes.STRONGHOLD.getImage(),
-				Dimension.OVERWORLD);
+				Dimension.OVERWORLD, false);
 	}
 
 	private double getAngleDelta(int ring, int structuresPerRing) {

--- a/src/main/java/amidst/mojangapi/world/icon/producer/StructureProducer.java
+++ b/src/main/java/amidst/mojangapi/world/icon/producer/StructureProducer.java
@@ -19,16 +19,18 @@ public class StructureProducer<T> extends WorldIconProducer<T> {
 	private final LocationChecker checker;
 	private final WorldIconTypeProvider<T> provider;
 	private final Dimension dimension;
+	private final boolean displayDimension;
 
 	public StructureProducer(Resolution resolution, int offsetInWorld,
 			LocationChecker checker, WorldIconTypeProvider<T> provider,
-			Dimension dimension) {
+			Dimension dimension, boolean displayDimension) {
 		this.resolution = resolution;
 		this.size = resolution.getStepsPerFragment();
 		this.offsetInWorld = offsetInWorld;
 		this.checker = checker;
 		this.provider = provider;
 		this.dimension = dimension;
+		this.displayDimension = displayDimension;
 	}
 
 	@Override
@@ -55,7 +57,8 @@ public class StructureProducer<T> extends WorldIconProducer<T> {
 				CoordinatesInWorld coordinates = createCoordinates(corner,
 						xRelativeToFragment, yRelativeToFragment);
 				consumer.accept(new WorldIcon(coordinates, worldIconType
-						.getName(), worldIconType.getImage(), dimension));
+						.getName(), worldIconType.getImage(), dimension,
+						displayDimension));
 			}
 		}
 	}


### PR DESCRIPTION
* the save capture image dialog is now a save dialog
* the save capture image dialog now suggests a meaningful name
* removed obvious dimension information from the world icons
* added a meaningful error message when there is no valid .minecraft directory
* fixed an issue with the "(Default)" launcher profile
* added the minecraft profile name to the main window title
* removed the Enabled All Layers menu item when if has no effect
* moved the Player Icons menu item from the Overworld section to the dimension independent section