### PR TITLE
Display Void texture in parallax.

### DIFF
--- a/src/main/java/amidst/gui/main/viewer/Drawer.java
+++ b/src/main/java/amidst/gui/main/viewer/Drawer.java
@@ -4,6 +4,7 @@ import java.awt.AlphaComposite;
 import java.awt.Color;
 import java.awt.FontMetrics;
 import java.awt.Graphics2D;
+import java.awt.Paint;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.RenderingHints;
@@ -145,7 +146,12 @@ public class Drawer {
 
 	@CalledOnlyBy(AmidstThread.EDT)
 	private void clear() {
-		g2d.setColor(Color.black);
+		
+		if (dimensionSetting.get().equals(Dimension.END)) {
+			g2d.setPaint(voidTexturePaint);
+		} else {
+			g2d.setColor(Color.black);		
+		}
 		g2d.fillRect(0, 0, viewerWidth, viewerHeight);
 	}
 
@@ -166,7 +172,6 @@ public class Drawer {
 				RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
 		AffineTransform originalGraphicsTransform = g2d.getTransform();
 		initOriginalLayerMatrix(originalGraphicsTransform);
-		drawVoidTexture();
 		drawLayers();
 		g2d.setTransform(originalGraphicsTransform);
 	}
@@ -181,16 +186,18 @@ public class Drawer {
 		originalLayerMatrix.scale(scale, scale);
 	}
 
+	/**
+	 * Fills the area of the fragments being drawn with a texture  
+	 * transformed and scaled to match the position/zoom of the layers.
+	 */
 	@CalledOnlyBy(AmidstThread.EDT)
-	private void drawVoidTexture() {
-		if (dimensionSetting.get().equals(Dimension.END)) {
-			g2d.setTransform(originalLayerMatrix);
-			g2d.scale(4, 4);
-			g2d.setPaint(voidTexturePaint);
-			int stepsPerFragment = Resolution.QUARTER.getStepsPerFragment();
-			g2d.fillRect(0, 0, stepsPerFragment * graph.getFragmentsPerRow(),
-					stepsPerFragment * graph.getFragmentsPerColumn());
-		}
+	private void drawBackgroundLayer(Paint paint) {
+		g2d.setTransform(originalLayerMatrix);
+		g2d.scale(4, 4);
+		g2d.setPaint(paint);
+		int stepsPerFragment = Resolution.QUARTER.getStepsPerFragment();
+		g2d.fillRect(0, 0, stepsPerFragment * graph.getFragmentsPerRow(),
+				stepsPerFragment * graph.getFragmentsPerColumn());
 	}
 
 	@CalledOnlyBy(AmidstThread.EDT)

--- a/src/main/java/amidst/gui/main/viewer/Drawer.java
+++ b/src/main/java/amidst/gui/main/viewer/Drawer.java
@@ -4,7 +4,6 @@ import java.awt.AlphaComposite;
 import java.awt.Color;
 import java.awt.FontMetrics;
 import java.awt.Graphics2D;
-import java.awt.Paint;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.RenderingHints;
@@ -23,7 +22,6 @@ import amidst.fragment.FragmentGraphItem;
 import amidst.fragment.drawer.FragmentDrawer;
 import amidst.gui.main.viewer.widget.Widget;
 import amidst.mojangapi.world.Dimension;
-import amidst.mojangapi.world.coordinates.Resolution;
 import amidst.settings.Setting;
 
 @NotThreadSafe
@@ -146,11 +144,10 @@ public class Drawer {
 
 	@CalledOnlyBy(AmidstThread.EDT)
 	private void clear() {
-		
 		if (dimensionSetting.get().equals(Dimension.END)) {
 			g2d.setPaint(voidTexturePaint);
 		} else {
-			g2d.setColor(Color.black);		
+			g2d.setColor(Color.black);
 		}
 		g2d.fillRect(0, 0, viewerWidth, viewerHeight);
 	}
@@ -184,20 +181,6 @@ public class Drawer {
 		originalLayerMatrix.translate(translator.getLeftOnScreen(),
 				translator.getTopOnScreen());
 		originalLayerMatrix.scale(scale, scale);
-	}
-
-	/**
-	 * Fills the area of the fragments being drawn with a texture  
-	 * transformed and scaled to match the position/zoom of the layers.
-	 */
-	@CalledOnlyBy(AmidstThread.EDT)
-	private void drawBackgroundLayer(Paint paint) {
-		g2d.setTransform(originalLayerMatrix);
-		g2d.scale(4, 4);
-		g2d.setPaint(paint);
-		int stepsPerFragment = Resolution.QUARTER.getStepsPerFragment();
-		g2d.fillRect(0, 0, stepsPerFragment * graph.getFragmentsPerRow(),
-				stepsPerFragment * graph.getFragmentsPerColumn());
 	}
 
 	@CalledOnlyBy(AmidstThread.EDT)


### PR DESCRIPTION
Changes the void so it's no longer scaled and translated with the End islands, instead they "float" in a parallax layer above it.

You might have made this change already, or have better ideas how to do it.