### PR TITLE
added logging information about the selected launcher profile

### DIFF
--- a/src/main/java/amidst/gui/profileselect/LocalProfileComponent.java
+++ b/src/main/java/amidst/gui/profileselect/LocalProfileComponent.java
@@ -77,8 +77,9 @@ public class LocalProfileComponent extends ProfileComponent {
 	@CalledOnlyBy(AmidstThread.WORKER)
 	private boolean tryLoad() {
 		try {
-			mojangApi
-					.set(profile.getName(), profileDirectory, versionDirectory);
+			Log.i("using minecraft launcher profile '" + getProfileName()
+					+ "' with versionId '" + getVersionName() + "'");
+			mojangApi.set(getProfileName(), profileDirectory, versionDirectory);
 			return true;
 		} catch (LocalMinecraftInterfaceCreationException e) {
 			Log.e(e.getMessage());


### PR DESCRIPTION
When a profile is selected via the profile select window, a log message is written that contains the profile name and the real Minecraft versionId (the recognised versionId was always logged later on). This enables us to quickly identify bug reports about modded Minecraft versions.