### PR TITLE
fixed widgets to not catch unrelated mouse events

### DIFF
--- a/src/main/java/amidst/gui/main/viewer/widget/DebugWidget.java
+++ b/src/main/java/amidst/gui/main/viewer/widget/DebugWidget.java
@@ -52,10 +52,4 @@ public class DebugWidget extends MultilineTextWidget {
 			return null;
 		}
 	}
-
-	@CalledOnlyBy(AmidstThread.EDT)
-	@Override
-	public boolean onMousePressed(int x, int y) {
-		return false;
-	}
 }

--- a/src/main/java/amidst/gui/main/viewer/widget/Widget.java
+++ b/src/main/java/amidst/gui/main/viewer/widget/Widget.java
@@ -303,7 +303,7 @@ public abstract class Widget {
 
 	@CalledOnlyBy(AmidstThread.EDT)
 	public boolean onClick(int x, int y) {
-		return true;
+		return false;
 	}
 
 	@CalledOnlyBy(AmidstThread.EDT)
@@ -313,7 +313,7 @@ public abstract class Widget {
 
 	@CalledOnlyBy(AmidstThread.EDT)
 	public boolean onMousePressed(int x, int y) {
-		return true;
+		return false;
 	}
 
 	@CalledOnlyBy(AmidstThread.EDT)


### PR DESCRIPTION
Previously, clicking on a text widget did not trigger a select world icon operation. However, the text widget does not do anything with the click event. I think it is more intuitive to select the underlying world icon.