### PR TITLE
Fix 8-by-8 block misalignment of End Islands map

### DIFF
--- a/src/main/java/amidst/fragment/colorprovider/TheEndColorProvider.java
+++ b/src/main/java/amidst/fragment/colorprovider/TheEndColorProvider.java
@@ -73,6 +73,10 @@ public class TheEndColorProvider implements ColorProvider {
 			int textureY, float maxInfluence) {
 		int result = VOID_TRANSPARENT_BLACK;
 		if (showRockyShores(chunkX, chunkY)) {
+			// Unfortunately the "rocky shore" miniature islands are not deterministic
+			// from the world seed, like chorus plants they are decorations whose PRNG state
+			// depends on the order chunks are created/explored in. This makes me sad :( 
+			// Let's use a symbolic texture, since we can't plot them properly. 
 			result = getRockyShoresTextureAt(textureX, textureY);
 		}
 		if (maxInfluence > INFLUENCE_FADE_FINISH) {

--- a/src/main/java/amidst/fragment/colorprovider/TheEndColorProvider.java
+++ b/src/main/java/amidst/fragment/colorprovider/TheEndColorProvider.java
@@ -73,10 +73,6 @@ public class TheEndColorProvider implements ColorProvider {
 			int textureY, float maxInfluence) {
 		int result = VOID_TRANSPARENT_BLACK;
 		if (showRockyShores(chunkX, chunkY)) {
-			// Unfortunately the "rocky shore" miniature islands are not deterministic
-			// from the world seed, like chorus plants they are decorations whose PRNG state
-			// depends on the order chunks are created/explored in. This makes me sad :( 
-			// Let's use a symbolic texture, since we can't plot them properly. 
 			result = getRockyShoresTextureAt(textureX, textureY);
 		}
 		if (maxInfluence > INFLUENCE_FADE_FINISH) {
@@ -109,6 +105,12 @@ public class TheEndColorProvider implements ColorProvider {
 		return TEXTURES.getRGB(textureX, textureY);
 	}
 
+	/**
+	 * Unfortunately the "rocky shore" miniature islands are not deterministic
+	 * from the world seed, like chorus plants they are decorations whose PRNG
+	 * state depends on the order chunks are created/explored in. This makes me
+	 * sad :( Let's use a symbolic texture, since we can't plot them properly.
+	 */
 	private int getRockyShoresTextureAt(int textureX, int textureY) {
 		return TEXTURES.getRGB(textureX, textureY + TEXTURES_HEIGHT);
 	}

--- a/src/main/java/amidst/mojangapi/world/oracle/EndIsland.java
+++ b/src/main/java/amidst/mojangapi/world/oracle/EndIsland.java
@@ -27,11 +27,11 @@ public class EndIsland {
 	 */
 	public float influenceAtBlock(int x, int y) {
 		// Add 8 blocks to both axis because all the Minecraft calculations are
-		// done using chunk coordinates and are converted as being the center of 
-		// the chunk whenever translated to block coordinates, whereas Amidst treats
-		// chunk coords as blockCoordinates >> 4. 
-		// This function also does a floating point divide by 16 instead of shifting
-		// by 4 in order to maintain sub-chunk accuracy with x & y.				
+		// done using chunk coordinates and are converted as being the center of
+		// the chunk whenever translated to block coordinates, whereas Amidst
+		// treats chunk coords as blockCoordinates >> 4.
+		// This function also does a floating point divide by 16 instead of
+		// shifting by 4 in order to maintain sub-chunk accuracy with x & y.
 		float chunkX = (x + 8) / 16.0f;
 		float chunkY = (y + 8) / 16.0f;
 		float adjustedX = (this.chunkX - chunkX) * 2 + X_ADJUSTMENT;

--- a/src/main/java/amidst/mojangapi/world/oracle/EndIsland.java
+++ b/src/main/java/amidst/mojangapi/world/oracle/EndIsland.java
@@ -26,8 +26,14 @@ public class EndIsland {
 	 * likely the lower the value).
 	 */
 	public float influenceAtBlock(int x, int y) {
-		float chunkX = x / 16.0f;
-		float chunkY = y / 16.0f;
+		// Add 8 blocks to both axis because all the Minecraft calculations are
+		// done using chunk coordinates and are converted as being the center of 
+		// the chunk whenever translated to block coordinates, whereas Amidst treats
+		// chunk coords as blockCoordinates >> 4. 
+		// This function also does a floating point divide by 16 instead of shifting
+		// by 4 in order to maintain sub-chunk accuracy with x & y.				
+		float chunkX = (x + 8) / 16.0f;
+		float chunkY = (y + 8) / 16.0f;
 		float adjustedX = (this.chunkX - chunkX) * 2 + X_ADJUSTMENT;
 		float adjustedY = (this.chunkY - chunkY) * 2 + Y_ADJUSTMENT;
 		return getResult(adjustedX * adjustedX + adjustedY * adjustedY);

--- a/src/main/java/amidst/mojangapi/world/oracle/EndIslandOracle.java
+++ b/src/main/java/amidst/mojangapi/world/oracle/EndIslandOracle.java
@@ -81,8 +81,6 @@ public class EndIslandOracle {
 
 	/**
 	 * Returns a list of all islands that might be touching a chunk-area.
-	 * ("Touching" includes the rocky-island-shore that extends from each
-	 * island)
 	 */
 	private List<EndIsland> findSurroundingIslands(int chunkX, int chunkY,
 			int chunksPerFragmentX, int chunksPerFragmentY) {


### PR DESCRIPTION
This problem is most visually noticeable when the grid is turned on - because (0,0) wasn't passing through the center of the Dragon's island, but fixing this also *slightly* improves teleport coordinates and using F3 coords to make sense of the map (by about 11.3 blocks).

