### PR TITLE
changed worker threads to be no daemon threads

### DIFF
--- a/src/main/java/amidst/threading/ThreadMaster.java
+++ b/src/main/java/amidst/threading/ThreadMaster.java
@@ -65,7 +65,6 @@ public class ThreadMaster {
 			@Override
 			public Thread newThread(Runnable r) {
 				Thread thread = new Thread(r);
-				thread.setDaemon(true);
 				thread.setPriority(Thread.MIN_PRIORITY);
 				return thread;
 			}


### PR DESCRIPTION
If a thread is a daemon thread, it does not keep the JVM alive. This means, that if all non-daemon threads are terminated, the JVM will just terminate all daemon threads and exit. This is a bad thing, if the daemon thread is currently writing to a file, because this will corrupt the file. Since the worker threads are used for IO, they should not be daemon threads.