### PR TITLE
converted the CrashWindow into a singleton

### DIFF
--- a/src/main/java/amidst/Amidst.java
+++ b/src/main/java/amidst/Amidst.java
@@ -162,12 +162,7 @@ public class Amidst {
 		SwingUtilities.invokeLater(new Runnable() {
 			@Override
 			public void run() {
-				new CrashWindow(message, allMessages, new Runnable() {
-					@Override
-					public void run() {
-						System.exit(4);
-					}
-				});
+				CrashWindow.show(message, allMessages, () -> System.exit(4));
 			}
 		});
 	}

--- a/src/main/java/amidst/gui/crash/CrashWindow.java
+++ b/src/main/java/amidst/gui/crash/CrashWindow.java
@@ -14,32 +14,67 @@ import javax.swing.ScrollPaneConstants;
 import javax.swing.border.LineBorder;
 
 import net.miginfocom.swing.MigLayout;
-import amidst.documentation.Immutable;
+import amidst.documentation.AmidstThread;
+import amidst.documentation.CalledOnlyBy;
+import amidst.documentation.NotThreadSafe;
 
-@Immutable
-public class CrashWindow {
+@NotThreadSafe
+public enum CrashWindow {
+	INSTANCE;
+
+	@CalledOnlyBy(AmidstThread.EDT)
+	public static void show(String message, String logMessages,
+			Runnable executeOnClose) {
+		INSTANCE.set(message, logMessages, executeOnClose);
+	}
+
+	private final JLabel messageLabel;
+	private final JTextArea logMessagesTextArea;
 	private final JFrame frame;
+	private volatile Runnable executeOnClose;
 
-	public CrashWindow(String message, String logMessages,
-			final Runnable executeOnClose) {
-		frame = new JFrame("Amidst crashed!");
-		frame.getContentPane().setLayout(new MigLayout());
-		frame.add(new JLabel(message), "growx, pushx, wrap");
-		frame.add(new JLabel("Please report this bug on:"),
+	@CalledOnlyBy(AmidstThread.EDT)
+	private CrashWindow() {
+		this.messageLabel = createMessageLabel();
+		this.logMessagesTextArea = createLogMessagesTextArea();
+		this.frame = createFrame();
+	}
+
+	@CalledOnlyBy(AmidstThread.EDT)
+	private JLabel createMessageLabel() {
+		return new JLabel();
+	}
+
+	@CalledOnlyBy(AmidstThread.EDT)
+	private JScrollPane createLogMessagesScrollPane(JTextArea textArea) {
+		JScrollPane result = new JScrollPane(textArea);
+		result.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED);
+		result.setBorder(new LineBorder(Color.darkGray, 1));
+		return result;
+	}
+
+	@CalledOnlyBy(AmidstThread.EDT)
+	private JFrame createFrame() {
+		JFrame result = new JFrame("Amidst crashed!");
+		result.getContentPane().setLayout(new MigLayout());
+		result.add(messageLabel, "growx, pushx, wrap");
+		result.add(new JLabel("Please report this bug on:"),
 				"growx, pushx, wrap");
-		frame.add(createReportingTextField(), "growx, pushx, wrap");
-		frame.add(createLogMessagesScrollPane(logMessages), "grow, push");
-		frame.setSize(800, 600);
-		frame.setVisible(true);
-		frame.addWindowListener(new WindowAdapter() {
+		result.add(createReportingTextField(), "growx, pushx, wrap");
+		result.add(createLogMessagesScrollPane(logMessagesTextArea),
+				"grow, push");
+		result.setSize(800, 600);
+		result.addWindowListener(new WindowAdapter() {
 			@Override
 			public void windowClosing(WindowEvent e) {
-				frame.dispose();
+				result.dispose();
 				executeOnClose.run();
 			}
 		});
+		return result;
 	}
 
+	@CalledOnlyBy(AmidstThread.EDT)
 	private JTextField createReportingTextField() {
 		JTextField result = new JTextField(
 				"https://github.com/toolbox4minecraft/amidst/issues/new");
@@ -48,18 +83,19 @@ public class CrashWindow {
 		return result;
 	}
 
-	private JScrollPane createLogMessagesScrollPane(String logMessages) {
-		JScrollPane result = new JScrollPane(
-				createLogMessagesTextArea(logMessages));
-		result.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED);
-		result.setBorder(new LineBorder(Color.darkGray, 1));
-		return result;
-	}
-
-	private JTextArea createLogMessagesTextArea(String logMessages) {
-		JTextArea result = new JTextArea(logMessages);
+	@CalledOnlyBy(AmidstThread.EDT)
+	private JTextArea createLogMessagesTextArea() {
+		JTextArea result = new JTextArea();
 		result.setEditable(false);
 		result.setFont(new Font("arial", Font.PLAIN, 10));
 		return result;
+	}
+
+	@CalledOnlyBy(AmidstThread.EDT)
+	public void set(String message, String logMessages, Runnable executeOnClose) {
+		this.messageLabel.setText(message);
+		this.logMessagesTextArea.setText(logMessages);
+		this.executeOnClose = executeOnClose;
+		this.frame.setVisible(true);
 	}
 }


### PR DESCRIPTION
Before, when there was a bug in the drawing loop this would have caused Amidst to open up to 50 crash windows per second (Amidst is capped at 50 FPS), which is really bad. Also, it is very likely that such bugs would not be reported, because the bug report cannot be copied.

Now, only one CrashWindow is opened and the displayed error message is updated when more crashes occur.