### PR TITLE
adjusted format of the seed history file

### DIFF
--- a/src/main/java/amidst/Application.java
+++ b/src/main/java/amidst/Application.java
@@ -58,7 +58,7 @@ public class Application {
 			LocalMinecraftInterfaceCreationException {
 		return new MojangApiBuilder(new WorldBuilder(
 				new PlayerInformationCacheImpl(),
-				SeedHistoryLogger.from(parameters.historyFile)), parameters)
+				SeedHistoryLogger.from(parameters.seedHistoryFile)), parameters)
 				.construct();
 	}
 

--- a/src/main/java/amidst/CommandLineParameters.java
+++ b/src/main/java/amidst/CommandLineParameters.java
@@ -27,7 +27,7 @@ public class CommandLineParameters {
 	public volatile String biomeProfilesDirectory;
 
 	@Option(name = "-history",                usage = "location of the seed history file",                   metaVar = "<file>")
-	public volatile String historyFile;
+	public volatile String seedHistoryFile;
 
 	@Option(name = "-log",                    usage = "location of the log file",                            metaVar = "<file>")
 	public volatile String logFile;

--- a/src/main/java/amidst/mojangapi/world/SeedHistoryLogger.java
+++ b/src/main/java/amidst/mojangapi/world/SeedHistoryLogger.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 import amidst.documentation.NotNull;
 import amidst.documentation.ThreadSafe;
 import amidst.logging.Log;
+import amidst.mojangapi.minecraftinterface.RecognisedVersion;
 
 @ThreadSafe
 public class SeedHistoryLogger {
@@ -32,14 +33,37 @@ public class SeedHistoryLogger {
 		this.createIfNecessary = createIfNecessary;
 	}
 
-	public synchronized void log(WorldSeed seed) {
+	public synchronized void log(RecognisedVersion recognisedVersion,
+			WorldSeed worldSeed) {
 		if (createIfNecessary && !file.exists()) {
 			tryCreateFile();
 		}
 		if (file.isFile()) {
-			writeLine(seed);
+			writeLine(createLine(recognisedVersion, worldSeed));
 		} else {
-			Log.w("unable to write seed to seed history log file");
+			Log.i("Not writing to seed history file, because it does not exist: "
+					+ file);
+		}
+	}
+
+	private String createLine(RecognisedVersion recognisedVersion,
+			WorldSeed worldSeed) {
+		String recognisedVersionName = recognisedVersion.getName();
+		String timestamp = createTimestamp();
+		String seedString = getSeedString(worldSeed);
+		return recognisedVersionName + ", " + timestamp + ", " + seedString;
+	}
+
+	private String createTimestamp() {
+		return new Timestamp(new Date().getTime()).toString();
+	}
+
+	private String getSeedString(WorldSeed worldSeed) {
+		String text = worldSeed.getText();
+		if (text != null) {
+			return worldSeed.getLong() + ", " + text;
+		} else {
+			return worldSeed.getLong() + "";
 		}
 	}
 
@@ -47,28 +71,18 @@ public class SeedHistoryLogger {
 		try {
 			file.createNewFile();
 		} catch (IOException e) {
-			Log.w("Unable to create history file: " + file);
+			Log.w("Unable to create seed history file: " + file);
 			e.printStackTrace();
 		}
 	}
 
-	private void writeLine(WorldSeed seed) {
+	private void writeLine(String line) {
 		try (PrintStream stream = new PrintStream(new FileOutputStream(file,
 				true))) {
-			stream.println(createLine(seed));
+			stream.println(line);
 		} catch (IOException e) {
-			Log.w("Unable to write to history file.");
+			Log.w("Unable to write to seed history file: " + file);
 			e.printStackTrace();
-		}
-	}
-
-	private String createLine(WorldSeed seed) {
-		String text = seed.getText();
-		if (text != null) {
-			return new Timestamp(new Date().getTime()) + " " + seed.getLong()
-					+ " " + text;
-		} else {
-			return new Timestamp(new Date().getTime()) + " " + seed.getLong();
 		}
 	}
 }

--- a/src/main/java/amidst/mojangapi/world/WorldBuilder.java
+++ b/src/main/java/amidst/mojangapi/world/WorldBuilder.java
@@ -9,6 +9,7 @@ import amidst.mojangapi.file.directory.SaveDirectory;
 import amidst.mojangapi.file.nbt.LevelDatNbt;
 import amidst.mojangapi.minecraftinterface.MinecraftInterface;
 import amidst.mojangapi.minecraftinterface.MinecraftInterfaceException;
+import amidst.mojangapi.minecraftinterface.RecognisedVersion;
 import amidst.mojangapi.world.coordinates.Resolution;
 import amidst.mojangapi.world.icon.locationchecker.EndCityLocationChecker;
 import amidst.mojangapi.world.icon.locationchecker.NetherFortressAlgorithm;
@@ -90,16 +91,17 @@ public class WorldBuilder {
 			VersionFeatures versionFeatures, BiomeDataOracle biomeDataOracle,
 			WorldSpawnOracle worldSpawnOracle)
 			throws MinecraftInterfaceException {
-		seedHistoryLogger.log(worldSeed);
-		long seed = worldSeed.getLong();
 		// @formatter:off
+		RecognisedVersion recognisedVersion = minecraftInterface.getRecognisedVersion();
+		seedHistoryLogger.log(recognisedVersion, worldSeed);
+		long seed = worldSeed.getLong();
 		minecraftInterface.createWorld(seed, worldType, generatorOptions);
 		return new World(
 				worldSeed,
 				worldType,
 				generatorOptions,
 				movablePlayerList,
-				minecraftInterface.getRecognisedVersion(),
+				recognisedVersion,
 				versionFeatures,
 				biomeDataOracle,
 				EndIslandOracle.from(  seed),


### PR DESCRIPTION
The new format for text seeds is:

    recognised version name, timestamp, seed as long, seed text

The new format for numeric seeds is:

    recognised version name, timestamp, seed as long

Note that there is no "," at the end, to be able to distinguish it from the empty seed text "".

I also adjusted some log messages.