### PR TITLE
fixed the windows wrapper to display stdout

### DIFF
--- a/travis-ci/wrapper-for-windows/pom.xml
+++ b/travis-ci/wrapper-for-windows/pom.xml
@@ -37,8 +37,7 @@
 							<goal>launch4j</goal>
 						</goals>
 						<configuration>
-							<headerType>gui</headerType>
-							<stayAlive>true</stayAlive>
+							<headerType>console</headerType>
 							<outfile>../../target/${amidst.build.filename}.exe</outfile>
 							<jar>../../target/${amidst.build.filename}.jar</jar>
 							<dontWrapJar>false</dontWrapJar>


### PR DESCRIPTION
`headerType=console` which implies `stayAlive=true` fixes this issue. Also, I was not able to notice any bad side-effect of this setting on the GUI.