### PR TITLE
revert: fixed the windows wrapper to display stdout

### DIFF
--- a/travis-ci/wrapper-for-windows/pom.xml
+++ b/travis-ci/wrapper-for-windows/pom.xml
@@ -37,7 +37,8 @@
 							<goal>launch4j</goal>
 						</goals>
 						<configuration>
-							<headerType>console</headerType>
+							<headerType>gui</headerType>
+							<stayAlive>true</stayAlive>
 							<outfile>../../target/${amidst.build.filename}.exe</outfile>
 							<jar>../../target/${amidst.build.filename}.jar</jar>
 							<dontWrapJar>false</dontWrapJar>


### PR DESCRIPTION
headerType=console which implies stayAlive=true fixes this issue. Also, I was not able to notice any bad side-effect of this setting on the GUI. (reverted from commit f1aa607c69f11cd2a82612b9a745c9ea9c4b6cf9)

This was reverted, because there is indeed an undesireable side-effect: A dos-box is opened, displaying stdout.