### PR TITLE
switched windows to use the default Java look and feel

### DIFF
--- a/src/main/java/amidst/Amidst.java
+++ b/src/main/java/amidst/Amidst.java
@@ -4,8 +4,6 @@ import java.io.File;
 
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
-import javax.swing.UIManager;
-import javax.swing.UnsupportedLookAndFeelException;
 
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
@@ -92,36 +90,15 @@ public class Amidst {
 		SwingUtilities.invokeLater(new Runnable() {
 			@Override
 			public void run() {
-				initGui();
+				setJava2DEnvironmentVariables();
 				doStartApplication(parameters, metadata);
 			}
 		});
 	}
 
-	private static void initGui() {
-		setJava2DEnvironmentVariables();
-		initLookAndFeel();
-	}
-
 	private static void setJava2DEnvironmentVariables() {
 		System.setProperty("sun.java2d.opengl", "True");
 		System.setProperty("sun.java2d.accthreshold", "0");
-	}
-
-	private static void initLookAndFeel() {
-		if (isWindows()) {
-			try {
-				UIManager.setLookAndFeel(UIManager
-						.getSystemLookAndFeelClassName());
-			} catch (ClassNotFoundException | InstantiationException
-					| IllegalAccessException | UnsupportedLookAndFeelException e) {
-				Log.printTraceStack(e);
-			}
-		}
-	}
-
-	private static boolean isWindows() {
-		return System.getProperty("os.name").toLowerCase().contains("win");
 	}
 
 	@CalledOnlyBy(AmidstThread.EDT)


### PR DESCRIPTION
This is because the Windows look and feel does not display checkboxes for menu items that have an icon. Also, the majority of the GUI is drawn by an own painting method, which does not rely on the look and feel. Thus, the decision to switch it should not have a great impact on the usability. Another advantage of this change is, that now all systems use the same look and feel, which should lower the chance of bugs happening on only one type of system.