### PR TITLE
added setting graphicsAcceleration

### DIFF
--- a/src/main/java/amidst/AmidstSettings.java
+++ b/src/main/java/amidst/AmidstSettings.java
@@ -28,6 +28,7 @@ public class AmidstSettings {
 	public final Setting<Boolean> showEndCities;
 	public final Setting<Boolean> enableAllLayers;
 
+	public final Setting<Boolean> graphicsAcceleration;
 	public final Setting<Boolean> smoothScrolling;
 	public final Setting<Boolean> fragmentFading;
 	public final Setting<Boolean> maxZoom;
@@ -46,29 +47,30 @@ public class AmidstSettings {
 	@CalledOnlyBy(AmidstThread.EDT)
 	public AmidstSettings(Preferences preferences) {
 		// @formatter:off
-		dimension                  = Settings.createDimension(preferences, "dimension",           Dimension.OVERWORLD);
-		showGrid                   = Settings.createBoolean(  preferences, "grid",                false);
-		showSlimeChunks            = Settings.createBoolean(  preferences, "slimeChunks",         false);
-		showSpawn                  = Settings.createBoolean(  preferences, "spawnIcon",           true);
-		showStrongholds            = Settings.createBoolean(  preferences, "strongholdIcons",     true);
-		showPlayers                = Settings.createBoolean(  preferences, "playerIcons",         true);
-		showVillages               = Settings.createBoolean(  preferences, "villageIcons",        true);
-		showTemples                = Settings.createBoolean(  preferences, "templeIcons",         true);
-		showMineshafts             = Settings.createBoolean(  preferences, "mineshaftIcons",      false);
-		showOceanMonuments         = Settings.createBoolean(  preferences, "oceanMonumentIcons",  true);
-		showNetherFortresses       = Settings.createBoolean(  preferences, "netherFortressIcons", false);
-		showEndCities              = Settings.createBoolean(  preferences, "endCityIcons",        false);
-		enableAllLayers            = Settings.createBoolean(  preferences, "enableAllLayers",     false);
+		dimension                  = Settings.createDimension(preferences, "dimension",            Dimension.OVERWORLD);
+		showGrid                   = Settings.createBoolean(  preferences, "grid",                 false);
+		showSlimeChunks            = Settings.createBoolean(  preferences, "slimeChunks",          false);
+		showSpawn                  = Settings.createBoolean(  preferences, "spawnIcon",            true);
+		showStrongholds            = Settings.createBoolean(  preferences, "strongholdIcons",      true);
+		showPlayers                = Settings.createBoolean(  preferences, "playerIcons",          true);
+		showVillages               = Settings.createBoolean(  preferences, "villageIcons",         true);
+		showTemples                = Settings.createBoolean(  preferences, "templeIcons",          true);
+		showMineshafts             = Settings.createBoolean(  preferences, "mineshaftIcons",       false);
+		showOceanMonuments         = Settings.createBoolean(  preferences, "oceanMonumentIcons",   true);
+		showNetherFortresses       = Settings.createBoolean(  preferences, "netherFortressIcons",  false);
+		showEndCities              = Settings.createBoolean(  preferences, "endCityIcons",         false);
+		enableAllLayers            = Settings.createBoolean(  preferences, "enableAllLayers",      false);
 		
-		smoothScrolling            = Settings.createBoolean(  preferences, "mapFlicking",         true);
-		fragmentFading             = Settings.createBoolean(  preferences, "mapFading",           true);
-		maxZoom                    = Settings.createBoolean(  preferences, "maxZoom",             true);
-		showFPS                    = Settings.createBoolean(  preferences, "showFPS",             true);
-		showScale                  = Settings.createBoolean(  preferences, "showScale",           true);
-		showDebug                  = Settings.createBoolean(  preferences, "showDebug",           false);
+		graphicsAcceleration       = Settings.createBoolean(  preferences, "graphicsAcceleration", true);
+		smoothScrolling            = Settings.createBoolean(  preferences, "mapFlicking",          true);
+		fragmentFading             = Settings.createBoolean(  preferences, "mapFading",            true);
+		maxZoom                    = Settings.createBoolean(  preferences, "maxZoom",              true);
+		showFPS                    = Settings.createBoolean(  preferences, "showFPS",              true);
+		showScale                  = Settings.createBoolean(  preferences, "showScale",            true);
+		showDebug                  = Settings.createBoolean(  preferences, "showDebug",            false);
 	
-		lastProfile                = Settings.createString(   preferences, "profile",             "");
-		worldType                  = Settings.createString(   preferences, "worldType",           WorldType.PROMPT_EACH_TIME);
+		lastProfile                = Settings.createString(   preferences, "profile",              "");
+		worldType                  = Settings.createString(   preferences, "worldType",            WorldType.PROMPT_EACH_TIME);
 		biomeProfileSelection = new BiomeProfileSelection(BiomeProfile.getDefaultProfile());
 		// @formatter:on
 	}

--- a/src/main/java/amidst/Application.java
+++ b/src/main/java/amidst/Application.java
@@ -1,7 +1,5 @@
 package amidst;
 
-import java.util.prefs.Preferences;
-
 import amidst.documentation.AmidstThread;
 import amidst.documentation.CalledOnlyBy;
 import amidst.documentation.NotThreadSafe;
@@ -35,21 +33,16 @@ public class Application {
 	private volatile MainWindow mainWindow;
 
 	@CalledOnlyBy(AmidstThread.EDT)
-	public Application(CommandLineParameters parameters, AmidstMetaData metadata)
+	public Application(CommandLineParameters parameters, AmidstMetaData metadata, AmidstSettings settings)
 			throws DotMinecraftDirectoryNotFoundException,
 			LocalMinecraftInterfaceCreationException {
 		this.parameters = parameters;
 		this.metadata = metadata;
-		this.settings = createSettings();
+		this.settings = settings;
 		this.mojangApi = createMojangApi();
 		this.biomeProfileDirectory = createBiomeProfileDirectory();
 		this.viewerFacadeBuilder = createViewerFacadeBuilder();
 		this.threadMaster = createThreadMaster();
-	}
-
-	@CalledOnlyBy(AmidstThread.EDT)
-	private AmidstSettings createSettings() {
-		return new AmidstSettings(Preferences.userNodeForPackage(Amidst.class));
 	}
 
 	@CalledOnlyBy(AmidstThread.EDT)

--- a/src/main/java/amidst/gui/main/Actions.java
+++ b/src/main/java/amidst/gui/main/Actions.java
@@ -244,6 +244,14 @@ public class Actions {
 	}
 
 	@CalledOnlyBy(AmidstThread.EDT)
+	public void disabledGraphicsAcceleration() {
+		mainWindow.displayMessage("Disabled Graphics Acceleration",
+				"You just disabled the Graphics Acceleration. This will lead to a significant drop in performance.\n"
+						+ "You need to restart Amidst for the changes to take effect.\n\n"
+						+ "If you did not mean to do this, you can re-enable the Graphics Acceleration via the Settings menu.");
+	}
+
+	@CalledOnlyBy(AmidstThread.EDT)
 	public void checkForUpdates() {
 		application.checkForUpdates(mainWindow);
 	}

--- a/src/main/java/amidst/gui/main/menu/AmidstMenuBuilder.java
+++ b/src/main/java/amidst/gui/main/menu/AmidstMenuBuilder.java
@@ -9,7 +9,10 @@ import javax.swing.JMenuItem;
 import amidst.AmidstSettings;
 import amidst.documentation.NotThreadSafe;
 import amidst.gui.main.Actions;
+import amidst.logging.Log;
 import amidst.mojangapi.world.WorldType;
+import amidst.settings.Setting;
+import amidst.settings.Settings;
 import amidst.settings.biomeprofile.BiomeProfileDirectory;
 
 @NotThreadSafe
@@ -100,7 +103,7 @@ public class AmidstMenuBuilder {
 		}
 		result.addSeparator();
 		// @formatter:off
-		Menus.checkbox(result, settings.graphicsAcceleration, "Graphics Acceleration", "ctrl A");
+		Menus.checkbox(result, wrapGraphicsAcceleration(),    "Graphics Acceleration", "ctrl A");
 		Menus.checkbox(result, settings.smoothScrolling,      "Smooth Scrolling",      "ctrl I");
 		Menus.checkbox(result, settings.fragmentFading,       "Fragment Fading");
 		Menus.checkbox(result, settings.maxZoom,              "Restrict Maximum Zoom", "ctrl Z");
@@ -109,6 +112,17 @@ public class AmidstMenuBuilder {
 		Menus.checkbox(result, settings.showDebug,            "Show Debug Information");
 		// @formatter:on
 		return result;
+	}
+
+	private Setting<Boolean> wrapGraphicsAcceleration() {
+		return Settings.createWithListener(settings.graphicsAcceleration, () -> {
+			if (settings.graphicsAcceleration.get()) {
+				Log.i("Graphics Acceleration: enabled");
+			} else {
+				Log.i("Graphics Acceleration: disabled");
+				actions.disabledGraphicsAcceleration();
+			}
+		});
 	}
 
 	private JMenu create_Settings_DefaultWorldType() {

--- a/src/main/java/amidst/gui/main/menu/AmidstMenuBuilder.java
+++ b/src/main/java/amidst/gui/main/menu/AmidstMenuBuilder.java
@@ -100,12 +100,13 @@ public class AmidstMenuBuilder {
 		}
 		result.addSeparator();
 		// @formatter:off
-		Menus.checkbox(result, settings.smoothScrolling,   "Smooth Scrolling",      "ctrl I");
-		Menus.checkbox(result, settings.fragmentFading,    "Fragment Fading");
-		Menus.checkbox(result, settings.maxZoom,           "Restrict Maximum Zoom", "ctrl Z");
-		Menus.checkbox(result, settings.showFPS,           "Show Framerate",        "ctrl L");
-		Menus.checkbox(result, settings.showScale,         "Show Scale",            "ctrl K");
-		Menus.checkbox(result, settings.showDebug,         "Show Debug Information");
+		Menus.checkbox(result, settings.graphicsAcceleration, "Graphics Acceleration", "ctrl A");
+		Menus.checkbox(result, settings.smoothScrolling,      "Smooth Scrolling",      "ctrl I");
+		Menus.checkbox(result, settings.fragmentFading,       "Fragment Fading");
+		Menus.checkbox(result, settings.maxZoom,              "Restrict Maximum Zoom", "ctrl Z");
+		Menus.checkbox(result, settings.showFPS,              "Show Framerate",        "ctrl L");
+		Menus.checkbox(result, settings.showScale,            "Show Scale",            "ctrl K");
+		Menus.checkbox(result, settings.showDebug,            "Show Debug Information");
 		// @formatter:on
 		return result;
 	}


### PR DESCRIPTION
This is a workaround for the white window issue described in #81 and #43. It adds a setting to completely disable the Graphics Acceleration. You can activate this setting by using the key stroke **CTRL + A** in the main window. You will not get any feedback after doing do. Also, you need to restart Amidst for the changes to take effect.

I am not sure whether we should publish this. It might lead to issues like the following:

The user disables Graphics Acceleration without knowing it by accidentally clicking around in the settings or by hitting **CTRL + A**. After the next restart, the Graphics performance is very bad. He does not know were this comes from and is lost. He might report a bug, but he might as well ignore it and live with the bad performance. This would be a great reduction in usability.