### PR TITLE
Dockerfile added to build jar file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM java:8
+RUN apt-get update
+RUN apt-get install -y maven
+RUN mkdir /target
+VOLUME /target
+COPY . /opt/amidst
+WORKDIR /opt/amidst
+RUN ["mvn", "clean"]
+RUN ["mvn", "package"]
+CMD ["cp", "target/amidst-v4-0.jar", "/target"]


### PR DESCRIPTION
The Dockerfile will build the jar file and copy it to a target volume.  This
allows users to compile the jar file without having Java 8 or Maven installed
on their local systems.  The resulting jar file will of course require Java 8.

To use the Dockerfile to build the binary, run the following commands:
```
docker build -t makeamidst .
docker run --rm -it -v `pwd`:/target makeamidst
```
These commands will construct a Docker container suitable for building the jar
file, and then build the jar file itself and copy it into the current directory.