### PR TITLE
Make zoom in/out key events work for all keyboard layouts

### DIFF
--- a/src/main/java/amidst/gui/main/MainWindow.java
+++ b/src/main/java/amidst/gui/main/MainWindow.java
@@ -125,10 +125,10 @@ public class MainWindow {
 	private void initKeyListener() {
 		frame.addKeyListener(new KeyAdapter() {
 			@Override
-			public void keyPressed(KeyEvent e) {
-				if (e.getKeyCode() == KeyEvent.VK_PLUS) {
+			public void keyTyped(KeyEvent e) {
+				if (e.getKeyChar() == '+') {
 					actions.adjustZoom(-1);
-				} else if (e.getKeyCode() == KeyEvent.VK_MINUS) {
+				} else if (e.getKeyChar() == '-') {
 					actions.adjustZoom(1);
 				}
 			}


### PR DESCRIPTION
I am affected by Issue #134 and I suggest using the keyTyped event instead keyPressed. This way + and - will work for zoom no matter how they are generated by the user's keyboard (even the keypad).