### PR TITLE
fixed String.toLowerCase() issues

### DIFF
--- a/src/main/java/amidst/Amidst.java
+++ b/src/main/java/amidst/Amidst.java
@@ -20,6 +20,7 @@ import amidst.gui.crash.CrashWindow;
 import amidst.logging.FileLogger;
 import amidst.logging.Log;
 import amidst.mojangapi.file.DotMinecraftDirectoryNotFoundException;
+import amidst.util.OperatingSystemDetector;
 
 @NotThreadSafe
 public class Amidst {
@@ -144,16 +145,12 @@ public class Amidst {
 	 * https://github.com/toolbox4minecraft/amidst/pull/94
 	 */
 	private static void enableOpenGLIfNecessary() {
-		if (isOSX()) {
+		if (OperatingSystemDetector.isMac()) {
 			Log.i("Enabling OpenGL.");
 			System.setProperty("sun.java2d.opengl", "True");
 		} else {
 			Log.i("Not using OpenGL.");
 		}
-	}
-
-	private static boolean isOSX() {
-		return System.getProperty("os.name").contains("OS X");
 	}
 
 	private static void forceGraphicsToVRAM() {

--- a/src/main/java/amidst/gui/main/Actions.java
+++ b/src/main/java/amidst/gui/main/Actions.java
@@ -31,6 +31,7 @@ import amidst.mojangapi.world.player.PlayerCoordinates;
 import amidst.settings.biomeprofile.BiomeProfile;
 import amidst.settings.biomeprofile.BiomeProfileSelection;
 import amidst.threading.WorkerExecutor;
+import amidst.util.FileExtensionChecker;
 
 @NotThreadSafe
 public class Actions {
@@ -336,7 +337,7 @@ public class Actions {
 	@CalledOnlyBy(AmidstThread.EDT)
 	private File appendPNGFileExtensionIfNecessary(File file) {
 		String filename = file.getAbsolutePath();
-		if (!filename.toLowerCase().endsWith(".png")) {
+		if (!FileExtensionChecker.hasFileExtension(filename, "png")) {
 			filename += ".png";
 		}
 		return new File(filename);

--- a/src/main/java/amidst/gui/main/PNGFileFilter.java
+++ b/src/main/java/amidst/gui/main/PNGFileFilter.java
@@ -5,6 +5,7 @@ import java.io.File;
 import javax.swing.filechooser.FileFilter;
 
 import amidst.documentation.NotThreadSafe;
+import amidst.util.FileExtensionChecker;
 
 @NotThreadSafe
 public class PNGFileFilter extends FileFilter {
@@ -13,7 +14,7 @@ public class PNGFileFilter extends FileFilter {
 		if (file.isDirectory()) {
 			return true;
 		} else {
-			return file.getName().toLowerCase().endsWith(".png");
+			return FileExtensionChecker.hasFileExtension(file.getName(), "png");
 		}
 	}
 

--- a/src/main/java/amidst/mojangapi/file/DotMinecraftDirectoryFinder.java
+++ b/src/main/java/amidst/mojangapi/file/DotMinecraftDirectoryFinder.java
@@ -5,6 +5,7 @@ import java.io.File;
 import amidst.documentation.Immutable;
 import amidst.documentation.NotNull;
 import amidst.logging.Log;
+import amidst.util.OperatingSystemDetector;
 
 @Immutable
 public enum DotMinecraftDirectoryFinder {
@@ -27,13 +28,12 @@ public enum DotMinecraftDirectoryFinder {
 	@NotNull
 	private static File getMinecraftDirectory() {
 		File home = new File(System.getProperty("user.home", "."));
-		String os = System.getProperty("os.name").toLowerCase();
-		if (os.contains("win")) {
+		if (OperatingSystemDetector.isWindows()) {
 			File appData = new File(System.getenv("APPDATA"));
 			if (appData.isDirectory()) {
 				return new File(appData, ".minecraft");
 			}
-		} else if (os.contains("mac")) {
+		} else if (OperatingSystemDetector.isMac()) {
 			return new File(home, "Library/Application Support/minecraft");
 		}
 		return new File(home, ".minecraft");

--- a/src/main/java/amidst/mojangapi/file/LibraryFinder.java
+++ b/src/main/java/amidst/mojangapi/file/LibraryFinder.java
@@ -10,6 +10,7 @@ import amidst.documentation.Immutable;
 import amidst.documentation.NotNull;
 import amidst.logging.Log;
 import amidst.mojangapi.file.json.version.LibraryJson;
+import amidst.util.OperatingSystemDetector;
 
 @Immutable
 public enum LibraryFinder {
@@ -48,10 +49,9 @@ public enum LibraryFinder {
 	}
 
 	private static String getOs() {
-		String osName = System.getProperty("os.name").toLowerCase();
-		if (osName.contains("win")) {
+		if (OperatingSystemDetector.isWindows()) {
 			return "windows";
-		} else if (osName.contains("mac")) {
+		} else if (OperatingSystemDetector.isMac()) {
 			return "osx";
 		} else {
 			return "linux";

--- a/src/main/java/amidst/mojangapi/world/icon/producer/SpawnProducer.java
+++ b/src/main/java/amidst/mojangapi/world/icon/producer/SpawnProducer.java
@@ -38,7 +38,7 @@ public class SpawnProducer extends CachedWorldIconProducer {
 	private WorldIcon createWorldIcon(CoordinatesInWorld coordinates) {
 		return new WorldIcon(
 				coordinates,
-				DefaultWorldIconTypes.SPAWN.getName(),
+				DefaultWorldIconTypes.SPAWN.getLabel(),
 				DefaultWorldIconTypes.SPAWN.getImage(),
 				Dimension.OVERWORLD,
 				false);

--- a/src/main/java/amidst/mojangapi/world/icon/producer/StrongholdProducer_Base.java
+++ b/src/main/java/amidst/mojangapi/world/icon/producer/StrongholdProducer_Base.java
@@ -85,7 +85,7 @@ public abstract class StrongholdProducer_Base extends CachedWorldIconProducer {
 	private WorldIcon createWorldIcon(CoordinatesInWorld coordinates) {
 		return new WorldIcon(
 				coordinates,
-				DefaultWorldIconTypes.STRONGHOLD.getName(),
+				DefaultWorldIconTypes.STRONGHOLD.getLabel(),
 				DefaultWorldIconTypes.STRONGHOLD.getImage(),
 				Dimension.OVERWORLD,
 				false);

--- a/src/main/java/amidst/mojangapi/world/icon/producer/StructureProducer.java
+++ b/src/main/java/amidst/mojangapi/world/icon/producer/StructureProducer.java
@@ -61,7 +61,7 @@ public class StructureProducer<T> extends WorldIconProducer<T> {
 				CoordinatesInWorld coordinates = createCoordinates(corner, xRelativeToFragment, yRelativeToFragment);
 				consumer.accept(new WorldIcon(
 						coordinates,
-						worldIconType.getName(),
+						worldIconType.getLabel(),
 						worldIconType.getImage(),
 						dimension,
 						displayDimension));

--- a/src/main/java/amidst/mojangapi/world/icon/type/DefaultWorldIconTypes.java
+++ b/src/main/java/amidst/mojangapi/world/icon/type/DefaultWorldIconTypes.java
@@ -6,41 +6,46 @@ import amidst.mojangapi.world.icon.WorldIconImage;
 
 /**
  * This is only a helper enum to have a central place where these constants can
- * be collected. However, it should not be used as a type. Note, that the name
- * of the enum elements represent the icon filename at the same time!
+ * be collected. However, it should not be used as a type.
  */
 @Immutable
 public enum DefaultWorldIconTypes {
 	// @formatter:off
-	NETHER_FORTRESS("Nether Fortress"),
-	PLAYER("Player"),
-	STRONGHOLD("Stronghold"),
-	JUNGLE("Jungle Temple"),
-	DESERT("Desert Temple"),
-	VILLAGE("Village"),
-	SPAWN("World Spawn"),
-	WITCH("Witch Hut"),
-	OCEAN_MONUMENT("Ocean Monument"),
-	IGLOO("Igloo"),
-	MINESHAFT("Mineshaft"),
-	END_CITY("Likely End City"),
-	POSSIBLE_END_CITY("Possible End City");
+	NETHER_FORTRESS     ("nether_fortress",   "Nether Fortress"),
+	PLAYER              ("player",            "Player"),
+	STRONGHOLD          ("stronghold",        "Stronghold"),
+	JUNGLE              ("jungle",            "Jungle Temple"),
+	DESERT              ("desert",            "Desert Temple"),
+	VILLAGE             ("village",           "Village"),
+	SPAWN               ("spawn",             "World Spawn"),
+	WITCH               ("witch",             "Witch Hut"),
+	OCEAN_MONUMENT      ("ocean_monument",    "Ocean Monument"),
+	IGLOO               ("igloo",             "Igloo"),
+	MINESHAFT           ("mineshaft",         "Mineshaft"),
+	END_CITY            ("end_city",          "Likely End City"),
+	POSSIBLE_END_CITY   ("possible_end_city", "Possible End City");
 	// @formatter:on
 
-	private final String name;
-	private final WorldIconImage image;
-
-	private DefaultWorldIconTypes(String name) {
-		this.name = name;
-		this.image = WorldIconImage.fromPixelTransparency(ResourceLoader.getImage(getFilename()));
+	private static String getFilename(String name) {
+		return "/amidst/gui/main/icon/" + name + ".png";
 	}
 
-	private String getFilename() {
-		return "/amidst/gui/main/icon/" + toString().toLowerCase() + ".png";
+	private final String name;
+	private final String label;
+	private final WorldIconImage image;
+
+	private DefaultWorldIconTypes(String name, String label) {
+		this.name = name;
+		this.label = label;
+		this.image = WorldIconImage.fromPixelTransparency(ResourceLoader.getImage(getFilename(name)));
 	}
 
 	public String getName() {
 		return name;
+	}
+
+	public String getLabel() {
+		return label;
 	}
 
 	public WorldIconImage getImage() {

--- a/src/main/java/amidst/util/FileExtensionChecker.java
+++ b/src/main/java/amidst/util/FileExtensionChecker.java
@@ -1,0 +1,20 @@
+package amidst.util;
+
+import amidst.documentation.Immutable;
+
+@Immutable
+public enum FileExtensionChecker {
+	;
+
+	/**
+	 * Checks whether the given filename has the given file extension.
+	 * 
+	 * @param filename
+	 *            The filename
+	 * @param extension
+	 *            The expected file extension without the leading "."
+	 */
+	public static boolean hasFileExtension(String filename, String extension) {
+		return filename.toLowerCase().endsWith("." + extension);
+	}
+}

--- a/src/main/java/amidst/util/OperatingSystemDetector.java
+++ b/src/main/java/amidst/util/OperatingSystemDetector.java
@@ -1,0 +1,26 @@
+package amidst.util;
+
+import amidst.documentation.Immutable;
+
+@Immutable
+public enum OperatingSystemDetector {
+	;
+
+	private static String OS_NAME = System.getProperty("os.name").toLowerCase();
+
+	public static boolean isWindows() {
+		return OS_NAME.indexOf("win") >= 0;
+	}
+
+	public static boolean isMac() {
+		return OS_NAME.indexOf("mac") >= 0;
+	}
+
+	public static boolean isUnix() {
+		return OS_NAME.indexOf("nix") >= 0 || OS_NAME.indexOf("nux") >= 0 || OS_NAME.indexOf("aix") > 0;
+	}
+
+	public static boolean isSolaris() {
+		return OS_NAME.indexOf("sunos") >= 0;
+	}
+}

--- a/src/test/java/amidst/mojangapi/world/testworld/DefaultTestWorldDirectoryDeclaration.java
+++ b/src/test/java/amidst/mojangapi/world/testworld/DefaultTestWorldDirectoryDeclaration.java
@@ -141,7 +141,7 @@ public enum DefaultTestWorldDirectoryDeclaration {
 			DefaultWorldIconTypes worldIconType) {
 		return world -> CoordinatesCollectionJson.extractWorldIcons(
 				producer.apply(world),
-				worldIconType.getName(),
+				worldIconType.getLabel(),
 				corner -> null,
 				OVERWORLD_FRAGMENTS_AROUND_ORIGIN,
 				MINIMAL_NUMBER_OF_COORDINATES);
@@ -150,7 +150,7 @@ public enum DefaultTestWorldDirectoryDeclaration {
 	private Function<World, CoordinatesCollectionJson> endCityExtractor(DefaultWorldIconTypes worldIconType) {
 		return world -> CoordinatesCollectionJson.extractWorldIcons(
 				world.getEndCityProducer(),
-				worldIconType.getName(),
+				worldIconType.getLabel(),
 				corner -> world.getEndIslandOracle().getAt(corner),
 				END_FRAGMENTS_AROUND_ORIGIN,
 				MINIMAL_NUMBER_OF_COORDINATES);


### PR DESCRIPTION
The conversion depends on the operating system's current Locale. Thus, it is not deterministic.

* I explicitly stated the filenames of the icons, instead of relying on the enum name.
* I collected all other occurences of toLowerCase in utility methods and made sure they are used correctly.
* toUpperCase has the same issue, but is currently not used by Amidst.