### PR TITLE
Seed Search Enhancements

### DIFF
--- a/src/main/java/amidst/gui/main/Actions.java
+++ b/src/main/java/amidst/gui/main/Actions.java
@@ -91,9 +91,15 @@ public class Actions {
 	@CalledOnlyBy(AmidstThread.EDT)
 	public void searchForRandom() {
 		try {
+			String helpMsg = "Please see [url] for details on setting up search.";
 			if (worldFinder == null) {
 				this.worldFinder = new WorldFinder(mojangApi);
-				worldFinder.configureFromFile(new File("search.json"));
+				try {
+					worldFinder.configureFromFile(new File("search.json"));
+				} catch (IllegalArgumentException e) {
+					mainWindow.displayMessage("", e.getMessage() + helpMsg);
+					return;
+				}
 			}
 			
 			if (worldFinder.canFindWorlds()) {
@@ -106,8 +112,7 @@ public class Actions {
 					}
 				}
 			} else {
-				mainWindow.displayMessage("Search not configured", 
-						"Please see [url] for details on setting up search");
+				mainWindow.displayMessage("Search not configured correctly", helpMsg);
 			}
 
 		} catch (LocalMinecraftInterfaceCreationException | IllegalStateException |

--- a/src/main/java/amidst/mojangapi/file/json/filter/BiomeFilterJson.java
+++ b/src/main/java/amidst/mojangapi/file/json/filter/BiomeFilterJson.java
@@ -11,6 +11,8 @@ import amidst.mojangapi.world.filter.BiomeFilter;
 public class BiomeFilterJson {
 	private volatile long distance;
 	private volatile List<String> biomes = Collections.emptyList();
+	private volatile String group = "Default";
+	private volatile long scoreValue = 0;
 
 	@GsonConstructor
 	public BiomeFilterJson() {
@@ -20,6 +22,6 @@ public class BiomeFilterJson {
 		if (biomes.size() == 0) {
 			throw new IllegalStateException("No biomes for filter");
 		}
-		return new BiomeFilter(distance, biomes);
+		return new BiomeFilter(distance, biomes, group, scoreValue);
 	}
 }

--- a/src/main/java/amidst/mojangapi/file/json/filter/StructureFilterJson.java
+++ b/src/main/java/amidst/mojangapi/file/json/filter/StructureFilterJson.java
@@ -8,7 +8,7 @@ import amidst.mojangapi.world.filter.StructureFilter;
 public class StructureFilterJson {
 	private volatile long distance;
 	private volatile String structure;
-	private volatile int minimum;
+	private volatile int minimum = 1;
 	private volatile String group = "Default";
 	private volatile long scoreValue = 0;
 

--- a/src/main/java/amidst/mojangapi/file/json/filter/StructureFilterJson.java
+++ b/src/main/java/amidst/mojangapi/file/json/filter/StructureFilterJson.java
@@ -9,12 +9,14 @@ public class StructureFilterJson {
 	private volatile long distance;
 	private volatile String structure;
 	private volatile int minimum;
+	private volatile String group = "Default";
+	private volatile long scoreValue = 0;
 
 	@GsonConstructor
 	public StructureFilterJson() {
 	}
 
 	public StructureFilter createStructureFilter() {
-		return new StructureFilter(distance, structure, minimum);
+		return new StructureFilter(distance, structure, minimum, group, scoreValue);
 	}
 }

--- a/src/main/java/amidst/mojangapi/file/json/filter/WorldFilterJson.java
+++ b/src/main/java/amidst/mojangapi/file/json/filter/WorldFilterJson.java
@@ -15,6 +15,7 @@ import amidst.mojangapi.world.filter.WorldFinder;
 public class WorldFilterJson {
 	private volatile boolean continuousSearch;
 	private volatile String searchName = "Unnamed Search";
+	private volatile long startingSeed = Long.MAX_VALUE;
 	private volatile List<BiomeFilterJson> biomeFilters = Collections.emptyList();
 	private volatile List<StructureFilterJson> structureFilters = Collections.emptyList();
 
@@ -43,5 +44,8 @@ public class WorldFilterJson {
 		WorldFilter worldFilter = new WorldFilter(largestBiomeFilterSize / 2, filters, searchName);
 		worldFinder.setWorldFilter(worldFilter);
 		worldFinder.setContinuous(continuousSearch);
+		if (startingSeed != Long.MAX_VALUE) {
+			worldFinder.setSeed(startingSeed);
+		}
 	}
 }

--- a/src/main/java/amidst/mojangapi/file/json/filter/WorldFilterJson.java
+++ b/src/main/java/amidst/mojangapi/file/json/filter/WorldFilterJson.java
@@ -7,12 +7,14 @@ import java.util.List;
 import amidst.documentation.GsonConstructor;
 import amidst.documentation.Immutable;
 import amidst.mojangapi.world.filter.BaseFilter;
+import amidst.mojangapi.world.filter.BiomeFilter;
 import amidst.mojangapi.world.filter.WorldFilter;
 import amidst.mojangapi.world.filter.WorldFinder;
 
 @Immutable
 public class WorldFilterJson {
 	private volatile boolean continuousSearch;
+	private volatile String searchName = "Unnamed Search";
 	private volatile List<BiomeFilterJson> biomeFilters = Collections.emptyList();
 	private volatile List<StructureFilterJson> structureFilters = Collections.emptyList();
 
@@ -21,16 +23,24 @@ public class WorldFilterJson {
 	}
 
 	public void configureWorldFinder(WorldFinder worldFinder) {
+		// Determine max size for buffering in WorldFilter
+		long largestBiomeFilterSize = 0;
+
 		List<BaseFilter> filters = new ArrayList<BaseFilter>();
 		for (BiomeFilterJson biomeFilterJson : biomeFilters) {
-			filters.add(biomeFilterJson.createBiomeFilter());
+			BiomeFilter filter = biomeFilterJson.createBiomeFilter();
+			if (filter.worldFilterSize > largestBiomeFilterSize) {
+				largestBiomeFilterSize = filter.worldFilterSize;
+			}
+			filters.add(filter);
 		}
 
 		for (StructureFilterJson structureFilterJson : structureFilters) {
 			filters.add(structureFilterJson.createStructureFilter());
 		}
 
-		WorldFilter worldFilter = new WorldFilter(0, filters);
+		//correct the world filter size to reflect distance from center not size
+		WorldFilter worldFilter = new WorldFilter(largestBiomeFilterSize / 2, filters, searchName);
 		worldFinder.setWorldFilter(worldFilter);
 		worldFinder.setContinuous(continuousSearch);
 	}

--- a/src/main/java/amidst/mojangapi/file/json/filter/WorldFilterJson.java
+++ b/src/main/java/amidst/mojangapi/file/json/filter/WorldFilterJson.java
@@ -13,7 +13,7 @@ import amidst.mojangapi.world.filter.WorldFinder;
 
 @Immutable
 public class WorldFilterJson {
-	private volatile boolean continuousSearch;
+	private volatile boolean continuousSearch = false;
 	private volatile String searchName = "Unnamed Search";
 	private volatile long startingSeed = Long.MAX_VALUE;
 	private volatile List<BiomeFilterJson> biomeFilters = Collections.emptyList();

--- a/src/main/java/amidst/mojangapi/world/SeedHistoryLogger.java
+++ b/src/main/java/amidst/mojangapi/world/SeedHistoryLogger.java
@@ -26,19 +26,44 @@ public class SeedHistoryLogger {
 
 	private final File file;
 	private final boolean createIfNecessary;
+	private final boolean logResultsOnly;
 
 	public SeedHistoryLogger(@NotNull File file, boolean createIfNecessary) {
 		Objects.requireNonNull(file);
 		this.file = file;
 		this.createIfNecessary = createIfNecessary;
+		this.logResultsOnly = false;
+	}
+
+	public SeedHistoryLogger(@NotNull File file, boolean createIfNecessary, boolean logResultsOnly) {
+		Objects.requireNonNull(file);
+		this.file = file;
+		this.createIfNecessary = createIfNecessary;
+		this.logResultsOnly = logResultsOnly;
 	}
 
 	public synchronized void log(RecognisedVersion recognisedVersion, WorldSeed worldSeed) {
+		// Any calls to this method will not be search results
+		// so suppress them based on the setting
+		if (this.logResultsOnly == false) {
+			if (createIfNecessary && !file.exists()) {
+				tryCreateFile();
+			}
+			if (file.isFile()) {
+				writeLine(createLine(recognisedVersion, worldSeed));
+			} else {
+				Log.i("Not writing to seed history file, because it does not exist: " + file);
+			}
+		}
+	}
+
+	public synchronized void log(RecognisedVersion recognisedVersion, WorldSeed worldSeed, String name, String grp,
+			int lvl) {
 		if (createIfNecessary && !file.exists()) {
 			tryCreateFile();
 		}
 		if (file.isFile()) {
-			writeLine(createLine(recognisedVersion, worldSeed));
+			writeLine(createLine(recognisedVersion, worldSeed, name, grp, lvl));
 		} else {
 			Log.i("Not writing to seed history file, because it does not exist: " + file);
 		}
@@ -49,6 +74,16 @@ public class SeedHistoryLogger {
 		String timestamp = createTimestamp();
 		String seedString = getSeedString(worldSeed);
 		return recognisedVersionName + ", " + timestamp + ", " + seedString;
+	}
+
+	private String createLine(RecognisedVersion recognisedVersion, WorldSeed worldSeed, String name, String grp,
+			int lvl) {
+		String recognisedVersionName = recognisedVersion.getName();
+		String timestamp = createTimestamp();
+		String seedString = getSeedString(worldSeed);
+		String matchLevel = Integer.toString(lvl);
+		return recognisedVersionName + ", " + timestamp + ", " + seedString + ", " + name + ", " + grp + ", "
+				+ matchLevel;
 	}
 
 	private String createTimestamp() {

--- a/src/main/java/amidst/mojangapi/world/filter/BaseFilter.java
+++ b/src/main/java/amidst/mojangapi/world/filter/BaseFilter.java
@@ -10,7 +10,7 @@ import amidst.mojangapi.world.coordinates.Resolution;
 public abstract class BaseFilter implements Comparable<BaseFilter> {
 	public final long worldFilterSize;
 	// this is a quarter of the whole world size in length not area.
-	// i.e. a worldFilterSize of 1024 will have a 
+	// i.e. a worldFilterSize of 1024 will have a
 	// quarterFilterSize of 256 NOT 512 as would be if area
 	public final long quarterFilterSize;
 	protected final CoordinatesInWorld corner;
@@ -22,8 +22,8 @@ public abstract class BaseFilter implements Comparable<BaseFilter> {
 			// Structure filters check spaces in fragment size, so filter
 			// distance not a multiple of
 			// fragment size will include more area in the filter than expected
-			throw new IllegalArgumentException(
-					"World filter size must be a multiple of " + Resolution.FRAGMENT.getStep());
+			throw new IllegalArgumentException("World filter size must be a multiple of "
+					+ Resolution.FRAGMENT.getStep() + "." + System.lineSeparator());
 		}
 
 		this.worldFilterSize = worldFilterDistance * 2;

--- a/src/main/java/amidst/mojangapi/world/filter/BaseFilter.java
+++ b/src/main/java/amidst/mojangapi/world/filter/BaseFilter.java
@@ -1,17 +1,21 @@
 package amidst.mojangapi.world.filter;
 
 import java.lang.IllegalArgumentException;
+import java.lang.Comparable;
 
 import amidst.mojangapi.world.World;
 import amidst.mojangapi.world.coordinates.CoordinatesInWorld;
 import amidst.mojangapi.world.coordinates.Resolution;
 
-public abstract class BaseFilter {
-	private short[][] evaluatedRegion = null;
-
-	protected final long worldFilterSize;
-	protected final long quarterFilterSize;
+public abstract class BaseFilter implements Comparable<BaseFilter> {
+	public final long worldFilterSize;
+	// this is a quarter of the whole world size in length not area.
+	// i.e. a worldFilterSize of 1024 will have a 
+	// quarterFilterSize of 256 NOT 512 as would be if area
+	public final long quarterFilterSize;
 	protected final CoordinatesInWorld corner;
+	protected String group;
+	protected long scoreValue;
 
 	public BaseFilter(long worldFilterDistance) {
 		if (worldFilterDistance % Resolution.FRAGMENT.getStep() != 0) {
@@ -27,18 +31,9 @@ public abstract class BaseFilter {
 		this.corner = new CoordinatesInWorld(-this.worldFilterSize / 2, -this.worldFilterSize / 2);
 	}
 
-	public final boolean isValid(World world) {
-		return isValid(world, getUpdatedRegion(world));
-	}
-
 	abstract protected boolean isValid(World world, short[][] region);
 
-	private short[][] getUpdatedRegion(World world) {
-		if (this.evaluatedRegion == null) {
-			this.evaluatedRegion = new short[(int) this.quarterFilterSize][(int) this.quarterFilterSize];
-		}
-
-		world.getBiomeDataOracle().populateArray(corner, evaluatedRegion, true);
-		return evaluatedRegion;
+	public int compareTo(BaseFilter f) {
+		return (int) (this.quarterFilterSize - f.quarterFilterSize);
 	}
 }

--- a/src/main/java/amidst/mojangapi/world/filter/BiomeFilter.java
+++ b/src/main/java/amidst/mojangapi/world/filter/BiomeFilter.java
@@ -10,8 +10,11 @@ import amidst.mojangapi.world.biome.Biome;
 public class BiomeFilter extends BaseFilter {
 	private final List<Biome> biomes;
 
-	public BiomeFilter(long worldFilterSize, List<String> biomeNames) {
+	public BiomeFilter(long worldFilterSize, List<String> biomeNames, String group, long scoreValue) {
 		super(worldFilterSize);
+
+		this.scoreValue = scoreValue;
+		this.group = group;
 
 		List<Biome> biomes = new ArrayList<>();
 		for (String name : biomeNames) {
@@ -21,8 +24,8 @@ public class BiomeFilter extends BaseFilter {
 				for (Biome possibleBiome : Biome.allBiomes()) {
 					possibleNames.add(possibleBiome.getName());
 				}
-				throw new IllegalArgumentException("Biome name '" + name + 
-						"' should be one of: " + String.join(", ", possibleNames));
+				throw new IllegalArgumentException(
+						"Biome name '" + name + "' should be one of: " + String.join(", ", possibleNames));
 			}
 			biomes.add(biome);
 		}
@@ -32,13 +35,19 @@ public class BiomeFilter extends BaseFilter {
 
 	@Override
 	protected boolean isValid(World world, short[][] region) {
-		for (short[] row : region) {
-			for (short entry : row) {
-				if (isValidBiome(entry)) {
+		// since the passed area can be larger than this filter
+		// determine the offset to only search the applicable area
+		long dataOffset = region.length - this.quarterFilterSize;
+
+		// loop over only the area specified by the filter
+		for (long x = dataOffset; x < dataOffset + this.quarterFilterSize; x++) {
+			for (long y = dataOffset; y < dataOffset + this.quarterFilterSize; y++) {
+				if (isValidBiome(region[(int) x][(int) y])) {
 					return true;
 				}
 			}
 		}
+
 		return false;
 	}
 

--- a/src/main/java/amidst/mojangapi/world/filter/StructureFilter.java
+++ b/src/main/java/amidst/mojangapi/world/filter/StructureFilter.java
@@ -48,6 +48,9 @@ public class StructureFilter extends BaseFilter {
 			for (long y = 0; y < worldFilterSize; y += 512) {
 				CoordinatesInWorld subCorner = CoordinatesInWorld.from(x, y).add(corner);
 				structureProducer.produce(subCorner, structureCollector, null);
+				if (multiWitchHutSearch == 0 && structureCollector.get().size() >= count) {
+					return true;
+				} 
 			}
 		}
 

--- a/src/main/java/amidst/mojangapi/world/filter/StructureFilter.java
+++ b/src/main/java/amidst/mojangapi/world/filter/StructureFilter.java
@@ -1,6 +1,7 @@
 package amidst.mojangapi.world.filter;
 
 import java.lang.IllegalArgumentException;
+import java.util.List;
 
 import amidst.mojangapi.world.World;
 import amidst.mojangapi.world.coordinates.CoordinatesInWorld;
@@ -12,12 +13,28 @@ import amidst.mojangapi.world.icon.type.DefaultWorldIconTypes;
 public class StructureFilter extends BaseFilter {
 	final int count;
 	final DefaultWorldIconTypes structure;
+	private final int multiWitchHutSearch;
 
-	public StructureFilter(long worldFilterSize, String structureName, int count) {
+	public StructureFilter(long worldFilterSize, String structureName, int count, String group, long scoreValue) {
 		super(worldFilterSize);
 
-		this.structure = DefaultWorldIconTypes.getByName(structureName);
+		if (structureName.equals("Quad Witch Hut")) {
+			this.multiWitchHutSearch = 4;
+			this.structure = DefaultWorldIconTypes.getByLabel("Witch Hut");
+		} else if (structureName.equals("Triple Witch Hut")) {
+			this.multiWitchHutSearch = 3;
+			this.structure = DefaultWorldIconTypes.getByLabel("Witch Hut");
+		} else if (structureName.equals("Dual Witch Hut")) {
+			this.multiWitchHutSearch = 2;
+			this.structure = DefaultWorldIconTypes.getByLabel("Witch Hut");
+		} else {
+			this.multiWitchHutSearch = 0;
+			this.structure = DefaultWorldIconTypes.getByLabel(structureName);
+		}
+
 		this.count = count;
+		this.scoreValue = scoreValue;
+		this.group = group;
 	}
 
 	@SuppressWarnings("unchecked")
@@ -34,7 +51,78 @@ public class StructureFilter extends BaseFilter {
 			}
 		}
 
-		return structureCollector.get().size() > count;
+		if (multiWitchHutSearch > 0) {
+			return checkMultiWitchHuts(structureCollector.get()) >= count;
+		} else {
+			return structureCollector.get().size() >= count;
+		}
+	}
+
+	/**
+	 * Iterate over the collection and then search for groups with a 256 max
+	 * distance between the two farthest houses. The method below will pick up
+	 * any configuration of huts where the max distance between any two is 256
+	 * 
+	 * @param structures
+	 *            The list of structures to check
+	 */
+	private int checkMultiWitchHuts(List<WorldIcon> structures) {
+		// The max distance allowable is 180 to make sure that
+		// diagonals are still within the 256 distance max
+		final long maxMultiStructDistance = 180;
+		int ret = 0;
+
+		for (WorldIcon s : structures) {
+			for (WorldIcon s1 : structures) {
+				// check range and for unique structure
+				if (s != s1 && IsWithinRange(s, s1, maxMultiStructDistance)) {
+					// if for dual witch huts
+					if (multiWitchHutSearch == 2) {
+						ret++;
+					} else {
+						for (WorldIcon s2 : structures) {
+							// check range and for unique structure
+							if (s != s2 && s1 != s2 && IsWithinRange(s, s2, maxMultiStructDistance)
+									&& IsWithinRange(s1, s2, maxMultiStructDistance)) {
+								// if for triple witch huts
+								if (multiWitchHutSearch == 3) {
+									ret++;
+								} else {
+									for (WorldIcon s3 : structures) {
+										// check range and for unique structure
+										if (s != s3 && s1 != s3 && s2 != s3
+												&& IsWithinRange(s, s3, maxMultiStructDistance)
+												&& IsWithinRange(s1, s3, maxMultiStructDistance)
+												&& IsWithinRange(s2, s3, maxMultiStructDistance)) {
+											// add to the return
+											// as this is a quad
+											ret++;
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		return ret;
+	}
+
+	/**
+	 * Checks to see that the passed structures are within the range specified
+	 * 
+	 * @param s1
+	 *            The first structure
+	 * @param s2
+	 *            The second structure
+	 * @param maxDistance
+	 *            The maximum distance allowed
+	 * @return true if the structures are within the range specified
+	 */
+	private boolean IsWithinRange(WorldIcon s1, WorldIcon s2, long maxDistance) {
+		return Math.abs(s1.getCoordinates().getX() - s2.getCoordinates().getX()) < maxDistance
+				&& Math.abs(s1.getCoordinates().getY() - s2.getCoordinates().getY()) < maxDistance;
 	}
 
 	@SuppressWarnings("rawtypes")
@@ -84,7 +172,7 @@ public class StructureFilter extends BaseFilter {
 
 		@Override
 		public void accept(WorldIcon worldIcon) {
-			if (worldIcon.getName().equals(acceptedStructure.getName())) {
+			if (worldIcon.getName().equals(acceptedStructure.getLabel())) {
 				super.accept(worldIcon);
 			}
 		}

--- a/src/main/java/amidst/mojangapi/world/filter/WorldFilter.java
+++ b/src/main/java/amidst/mojangapi/world/filter/WorldFilter.java
@@ -1,16 +1,48 @@
 package amidst.mojangapi.world.filter;
 
 import java.util.List;
+import java.util.Map;
+import java.util.ArrayList;
+import java.util.HashMap;
 
+import amidst.mojangapi.world.SeedHistoryLogger;
 import amidst.mojangapi.world.World;
 
 public class WorldFilter extends BaseFilter {
 	private final List<BaseFilter> filterList;
+	private final String name;
+	private SeedHistoryLogger matchLogger;
 
-	public WorldFilter(long worldFilterSize, List<BaseFilter> filters) {
+	/**
+	 * The buffer array to pass to individual filters. This will be done at
+	 * quarter filter resolution to improve memory and performance with
+	 * negligible cost to accuracy
+	 */
+	private short[][] evaluatedRegion;
+
+	public WorldFilter(long worldFilterSize, List<BaseFilter> filters, String name) {
 		super(worldFilterSize);
 
-		filterList = filters;
+		this.name = name;
+		this.filterList = filters;
+	}
+
+	public void setLogger(SeedHistoryLogger logger) {
+		this.matchLogger = logger;
+	}
+
+	public boolean isValid(World world) {
+		if (this.evaluatedRegion == null) {
+			// init at quarter size
+			this.evaluatedRegion = new short[(int) this.quarterFilterSize][(int) this.quarterFilterSize];
+		}
+
+		// fill the data array using quarter resolution
+		// this increases performance and reduces memory usage
+		// with negligible cost to accuracy
+		world.getBiomeDataOracle().populateArray(corner, this.evaluatedRegion, true);
+
+		return isValid(world, this.evaluatedRegion);
 	}
 
 	@Override
@@ -18,15 +50,41 @@ public class WorldFilter extends BaseFilter {
 		if (filterList.size() == 0) {
 			return true;
 		}
-
+		// create a map of the different groupings
+		Map<String, List<BaseFilter>> map = new HashMap<String, List<BaseFilter>>();
 		for (BaseFilter filter : filterList) {
-			if (!filter.isValid(world)) {
-				return false;
+			if (!map.containsKey(filter.group)) {
+				List<BaseFilter> list = new ArrayList<BaseFilter>();
+				list.add(filter);
+				map.put(filter.group, list);
+			} else {
+				map.get(filter.group).add(filter);
 			}
 		}
-		return true;
+
+		boolean hadMatch = false;
+		for (Map.Entry<String, List<BaseFilter>> entry : map.entrySet()) {
+			int score = 0;
+			boolean isMatch = true;
+			for (BaseFilter filter : entry.getValue()) {
+				if (filter.isValid(world, evaluatedRegion)) {
+					score += filter.scoreValue;
+				} else if (filter.scoreValue == 0) {
+					isMatch = false;
+					// break as zero scores are required
+					// and this filter group will fail
+					break;
+				}
+			}
+			if (isMatch) {
+				matchLogger.log(world.getRecognisedVersion(), world.getWorldSeed(), this.name, entry.getKey(), score);
+				hadMatch = true;
+			}
+		}
+
+		return hadMatch;
 	}
-	
+
 	public boolean hasFilters() {
 		return filterList.size() > 0;
 	}

--- a/src/main/java/amidst/mojangapi/world/filter/WorldFinder.java
+++ b/src/main/java/amidst/mojangapi/world/filter/WorldFinder.java
@@ -25,7 +25,9 @@ public class WorldFinder {
 
 	private WorldFilter worldFilter;
 	private SeedHistoryLogger logger = new SeedHistoryLogger(new File("SearchResults.txt"), true, true);
+	WorldSeed worldSeed;
 	private boolean continuous = false;
+	private boolean useCustomSeed = false;
 	private boolean searching = false;
 
 	public WorldFinder(MojangApi originalMojangApi) throws LocalMinecraftInterfaceCreationException {
@@ -48,6 +50,11 @@ public class WorldFinder {
 
 	public void setContinuous(boolean continuous) {
 		this.continuous = continuous;
+	}
+
+	public void setSeed(long seed) {
+		this.worldSeed = WorldSeed.fromSaveGame(seed);
+		this.useCustomSeed = true;
 	}
 
 	public boolean isSearching() {
@@ -81,8 +88,12 @@ public class WorldFinder {
 	private WorldSeed findRandomWorld(WorldType worldType) throws IllegalStateException, MinecraftInterfaceException {
 		World world;
 		do {
-			WorldSeed worldSeed = WorldSeed.random();
-			world = mojangApi.createWorldFromSeed(worldSeed, worldType);
+			if (this.useCustomSeed) {
+				this.worldSeed = WorldSeed.fromSaveGame(this.worldSeed.getLong() + 1);
+			} else {
+				this.worldSeed = WorldSeed.random();
+			}
+			world = mojangApi.createWorldFromSeed(this.worldSeed, worldType);
 		} while (!worldFilter.isValid(world));
 		return world.getWorldSeed();
 	}

--- a/src/main/java/amidst/mojangapi/world/filter/WorldFinder.java
+++ b/src/main/java/amidst/mojangapi/world/filter/WorldFinder.java
@@ -9,7 +9,6 @@ import amidst.mojangapi.file.MojangApiParsingException;
 import amidst.mojangapi.file.json.JsonReader;
 import amidst.mojangapi.file.json.filter.WorldFilterJson;
 import amidst.mojangapi.minecraftinterface.MinecraftInterfaceException;
-import amidst.mojangapi.minecraftinterface.RecognisedVersion;
 import amidst.mojangapi.minecraftinterface.local.LocalMinecraftInterfaceCreationException;
 import amidst.mojangapi.world.SeedHistoryLogger;
 import amidst.mojangapi.world.World;
@@ -25,11 +24,12 @@ public class WorldFinder {
 	private final WorldBuilder worldBuilder;
 
 	private WorldFilter worldFilter;
+	private SeedHistoryLogger logger = new SeedHistoryLogger(new File("SearchResults.txt"), true, true);
 	private boolean continuous = false;
 	private boolean searching = false;
 
 	public WorldFinder(MojangApi originalMojangApi) throws LocalMinecraftInterfaceCreationException {
-		this.worldBuilder = new WorldBuilder(null, new SilentLogger());
+		this.worldBuilder = new WorldBuilder(null, logger);
 		this.originalMojangApi = originalMojangApi;
 		this.mojangApi = originalMojangApi.duplicateApiInterface(this.worldBuilder);
 	}
@@ -43,16 +43,17 @@ public class WorldFinder {
 
 	public void setWorldFilter(WorldFilter filter) {
 		this.worldFilter = filter;
+		this.worldFilter.setLogger(logger);
 	}
 
 	public void setContinuous(boolean continuous) {
 		this.continuous = continuous;
 	}
-	
+
 	public boolean isSearching() {
 		return searching;
 	}
-	
+
 	public boolean canFindWorlds() {
 		return worldFilter != null && worldFilter.hasFilters();
 	}
@@ -84,17 +85,5 @@ public class WorldFinder {
 			world = mojangApi.createWorldFromSeed(worldSeed, worldType);
 		} while (!worldFilter.isValid(world));
 		return world.getWorldSeed();
-	}
-
-	private static class SilentLogger extends SeedHistoryLogger {
-		public SilentLogger() {
-			super(new File("history.txt"), false);
-		}
-
-		@Override
-		public synchronized void log(RecognisedVersion recognisedVersion, WorldSeed worldSeed) {
-			// We don't want to log any of the seeds that don't meet the filter
-			// requirements
-		}
 	}
 }

--- a/src/main/java/amidst/mojangapi/world/icon/type/DefaultWorldIconTypes.java
+++ b/src/main/java/amidst/mojangapi/world/icon/type/DefaultWorldIconTypes.java
@@ -34,12 +34,12 @@ public enum DefaultWorldIconTypes {
 	private static final Map<String, DefaultWorldIconTypes> typeMap = new HashMap<String, DefaultWorldIconTypes>();
 	static {
 		for (DefaultWorldIconTypes iconType : EnumSet.allOf(DefaultWorldIconTypes.class)) {
-			typeMap.put(iconType.getName(), iconType);
+			typeMap.put(iconType.getLabel(), iconType);
 		}
 	}
 	
-	public static DefaultWorldIconTypes getByName(String name) {
-		return typeMap.get(name);
+	public static DefaultWorldIconTypes getByLabel(String label) {
+		return typeMap.get(label);
 	}
 
 	public static Set<String> getValidTypeNames() {


### PR DESCRIPTION
Implemented a number of features discussed in #120. This PR does the following:

Sets structure filters to have the setting minimum defaulted to 1 to make usage easier.

Set continuousSearch to default to false so it is not a required setting.

Added a search setting to allow a user to set the starting seed for a search so that searches can be done without concerns of PRNG problems for longer searches.

Added the ability to search for witch hut clusters of 2-4.

Buffered the biome data on a search basis for better performance and lower memory usage. In some test cases memory usage was reduced by 7/8ths.

Added search groups and scoring for different filters to enhance traceability of logged results and to allow multiple searches to be run on the seed without having to do multiple separate searches.

Added a higher detail log (SearchResults.txt) that is created or appended to when a search is running.

Added a search name to improve the traceability of search in the log.

All behavior has also been documented [here](https://github.com/jmessenger235/amidst/wiki/Demo) and can be moved to the wiki when the PR is merged.

The code changes were tested with the following filters and have comments on the reason:

``` javascript
// basic test to check that scoring, naming, and grouping were working correctly
{
  "continuousSearch": true,
  "searchName": "Test Search",
  "biomeFilters": [
    {"distance": 512, "biomes": ["Mushroom Island", "Mushroom Island M"]},
    {"distance": 512, "biomes": ["Ice Plains Spikes"], "group": "Ice"},
    {"distance": 512, "biomes": ["Mega Spruce Taiga", "Mega Spruce Taiga (Hills)"], "group": "Ice"}
  ],
  "structureFilters": [
    {"distance": 1024, "structure": "Village", "minimum": 1},
    {"distance": 512, "structure": "Village", "minimum": 1, "scoreValue": 10}
  ]
}

//test to ensure that witch hut clusters were working.
{
  "continuousSearch": true,
  "searchName": "Test Quad Search",
  "structureFilters": [
    {"distance": 4096, "structure": "Dual Witch Hut", "minimum": 1},
    {"distance": 4096, "structure": "Triple Witch Hut", "minimum": 1, "scoreValue": 10},
    {"distance": 4096, "structure": "Quad Witch Hut", "minimum": 1, "scoreValue": 100}
  ]
}

//test to ensure that witch hut clusters were working without the double hut match noise
{
  "continuousSearch": true,
  "searchName": "Test Quad Search2",
  "structureFilters": [
    {"distance": 4096, "structure": "Triple Witch Hut", "minimum": 1},
    {"distance": 4096, "structure": "Quad Witch Hut", "minimum": 1, "scoreValue": 10}
  ]
}

// tested in debug to make sure that all structures were still supported properly
// this was done to make sure the structure provider was still working after the tweaks
// that were made to get the Temple provider type filters working properly
{
  "continuousSearch": true,
  "searchName": "Test struc ct",
  "structureFilters": [
    {"distance": 8192, "structure": "Witch Hut", "minimum": 1},
    {"distance": 8192, "structure": "Stronghold", "minimum": 1},
    {"distance": 8192, "structure": "Jungle Temple", "minimum": 1},
    {"distance": 8192, "structure": "Desert Temple", "minimum": 1},
    {"distance": 8192, "structure": "Village", "minimum": 1},
    {"distance": 8192, "structure": "Witch Hut", "minimum": 1},
    {"distance": 8192, "structure": "Ocean Monument", "minimum": 1},
    {"distance": 8192, "structure": "Igloo", "minimum": 1},
    {"distance": 8192, "structure": "Mineshaft", "minimum": 1},
    {"distance": 4096, "structure": "Dual Witch Hut", "minimum": 1, "scoreValue": 1},
    {"distance": 4096, "structure": "Triple Witch Hut", "minimum": 1, "scoreValue": 10},
    {"distance": 4096, "structure": "Quad Witch Hut", "minimum": 1, "scoreValue": 100}
  ]
}

// tested to ensure defaults were correct
{
  "structureFilters": [
    {"distance": 4096, "structure": "Dual Witch Hut"},
  ]
}
```
