### PR TITLE
Retrieve Steve's head instead of returning null

### DIFF
--- a/src/main/java/amidst/mojangapi/file/json/PlayerInformationRetriever.java
+++ b/src/main/java/amidst/mojangapi/file/json/PlayerInformationRetriever.java
@@ -18,7 +18,6 @@ public enum PlayerInformationRetriever {
 	;
 
 	private static final String SIMPLE_PLAYER_SKIN_URL = "http://s3.amazonaws.com/MinecraftSkins/";
-	private static final String STEVE_SKIN_URL = "http://assets.mojang.com/SkinTemplates/steve.png";
 
 	public static PlayerJson tryGetPlayerJsonByName(String name) {
 		try {
@@ -43,11 +42,7 @@ public enum PlayerInformationRetriever {
 			return getPlayerHeadByName(name);
 		} catch (IOException | NullPointerException e) {
 			AmidstLogger.warn("unable to load player head by name: " + name);
-			try {
-				return getPlayerHeadBySkinUrl(STEVE_SKIN_URL);
-			} catch (IOException | NullPointerException x) {
-				return null;
-			}
+			return null;
 		}
 	}
 
@@ -56,11 +51,7 @@ public enum PlayerInformationRetriever {
 			return getPlayerHeadBySkinUrl(skinUrl);
 		} catch (IOException | NullPointerException e) {
 			AmidstLogger.warn("unable to load player head by skin url: " + skinUrl);
-			try {
-				return getPlayerHeadBySkinUrl(STEVE_SKIN_URL);
-			} catch (IOException | NullPointerException x) {
-				return null;
-			}
+			return null;
 		}
 	}
 

--- a/src/main/java/amidst/mojangapi/file/json/PlayerInformationRetriever.java
+++ b/src/main/java/amidst/mojangapi/file/json/PlayerInformationRetriever.java
@@ -18,6 +18,7 @@ public enum PlayerInformationRetriever {
 	;
 
 	private static final String SIMPLE_PLAYER_SKIN_URL = "http://s3.amazonaws.com/MinecraftSkins/";
+	private static final String STEVE_SKIN_URL = "http://assets.mojang.com/SkinTemplates/steve.png";
 
 	public static PlayerJson tryGetPlayerJsonByName(String name) {
 		try {
@@ -42,7 +43,11 @@ public enum PlayerInformationRetriever {
 			return getPlayerHeadByName(name);
 		} catch (IOException | NullPointerException e) {
 			AmidstLogger.warn("unable to load player head by name: " + name);
-			return null;
+			try {
+				return getPlayerHeadBySkinUrl(STEVE_SKIN_URL);
+			} catch (IOException | NullPointerException x) {
+				return null;
+			}
 		}
 	}
 
@@ -51,7 +56,11 @@ public enum PlayerInformationRetriever {
 			return getPlayerHeadBySkinUrl(skinUrl);
 		} catch (IOException | NullPointerException e) {
 			AmidstLogger.warn("unable to load player head by skin url: " + skinUrl);
-			return null;
+			try {
+				return getPlayerHeadBySkinUrl(STEVE_SKIN_URL);
+			} catch (IOException | NullPointerException x) {
+				return null;
+			}
 		}
 	}
 

--- a/src/main/java/amidst/mojangapi/world/player/PlayerInformation.java
+++ b/src/main/java/amidst/mojangapi/world/player/PlayerInformation.java
@@ -1,5 +1,7 @@
 package amidst.mojangapi.world.player;
 
+import java.awt.image.BufferedImage;
+
 import amidst.documentation.Immutable;
 import amidst.documentation.NotNull;
 import amidst.mojangapi.file.MojangApiParsingException;
@@ -59,15 +61,19 @@ public class PlayerInformation {
 	}
 
 	private static WorldIconImage tryGetPlayerHeadBySkinUrl(PlayerJson player) {
+		BufferedImage head;
 		try {
-			return WorldIconImage.from(PlayerInformationRetriever.tryGetPlayerHeadBySkinUrl(player.getSkinUrl()));
+			head = PlayerInformationRetriever.tryGetPlayerHeadBySkinUrl(player.getSkinUrl());
+			return head != null ? WorldIconImage.from(head) : null;
 		} catch (MojangApiParsingException e) {
 			return null;
 		}
 	}
 
 	private static WorldIconImage tryGetPlayerHeadByName(String name) {
-		return WorldIconImage.from(PlayerInformationRetriever.tryGetPlayerHeadByName(name));
+		BufferedImage head;
+		head = PlayerInformationRetriever.tryGetPlayerHeadByName(name);
+		return head != null ? WorldIconImage.from(head) : null;
 	}
 
 	@NotNull


### PR DESCRIPTION
In case of not being able to retrieve player's head by name or skin url amidst opens an error window. With this fix a default Steve's head is tried first before it returns null. I guess we could also use supplied "player.png" instead.