### PR TITLE
Create WorldOptions class

### DIFF
--- a/src/main/java/amidst/gui/main/Actions.java
+++ b/src/main/java/amidst/gui/main/Actions.java
@@ -21,6 +21,7 @@ import amidst.gui.main.menu.MovePlayerPopupMenu;
 import amidst.gui.main.viewer.ViewerFacade;
 import amidst.gui.seedsearcher.SeedSearcherWindow;
 import amidst.logging.AmidstLogger;
+import amidst.mojangapi.world.WorldOptions;
 import amidst.mojangapi.world.WorldSeed;
 import amidst.mojangapi.world.WorldType;
 import amidst.mojangapi.world.coordinates.CoordinatesInWorld;
@@ -73,7 +74,7 @@ public class Actions {
 	private void newFromSeed(WorldSeed worldSeed) {
 		WorldType worldType = dialogs.askForWorldType();
 		if (worldType != null) {
-			worldSwitcher.displayWorld(worldSeed, worldType);
+			worldSwitcher.displayWorld(new WorldOptions(worldSeed, worldType));
 		}
 	}
 

--- a/src/main/java/amidst/gui/main/WorldSwitcher.java
+++ b/src/main/java/amidst/gui/main/WorldSwitcher.java
@@ -20,8 +20,7 @@ import amidst.mojangapi.RunningLauncherProfile;
 import amidst.mojangapi.file.MinecraftInstallation;
 import amidst.mojangapi.minecraftinterface.MinecraftInterfaceException;
 import amidst.mojangapi.world.World;
-import amidst.mojangapi.world.WorldSeed;
-import amidst.mojangapi.world.WorldType;
+import amidst.mojangapi.world.WorldOptions;
 import amidst.mojangapi.world.player.MovablePlayerList;
 import amidst.mojangapi.world.player.WorldPlayerType;
 import amidst.parsing.FormatException;
@@ -62,10 +61,10 @@ public class WorldSwitcher {
 	}
 
 	@CalledOnlyBy(AmidstThread.EDT)
-	public void displayWorld(WorldSeed worldSeed, WorldType worldType) {
+	public void displayWorld(WorldOptions worldOptions) {
 		try {
 			clearViewerFacade();
-			setWorld(runningLauncherProfile.createWorldFromSeed(worldSeed, worldType));
+			setWorld(runningLauncherProfile.createWorld(worldOptions));
 		} catch (IllegalStateException | MinecraftInterfaceException e) {
 			AmidstLogger.warn(e);
 			dialogs.displayError(e);

--- a/src/main/java/amidst/gui/seedsearcher/SeedSearcherWindow.java
+++ b/src/main/java/amidst/gui/seedsearcher/SeedSearcherWindow.java
@@ -21,6 +21,7 @@ import amidst.gui.main.MainWindowDialogs;
 import amidst.gui.main.WorldSwitcher;
 import amidst.logging.AmidstLogger;
 import amidst.mojangapi.file.json.filter.WorldFilterJson_MatchAll;
+import amidst.mojangapi.world.WorldOptions;
 import amidst.mojangapi.world.WorldSeed;
 import amidst.mojangapi.world.WorldType;
 import amidst.mojangapi.world.filter.WorldFilter;
@@ -117,7 +118,7 @@ public class SeedSearcherWindow {
 			if (configuration.isPresent()) {
 				SeedSearcherConfiguration seedSearcherConfiguration = configuration.get();
 				WorldType worldType = seedSearcherConfiguration.getWorldType();
-				seedSearcher.search(seedSearcherConfiguration, worldSeed -> seedFound(worldSeed, worldType));
+				seedSearcher.search(seedSearcherConfiguration, worldOptions -> seedFound(worldOptions));
 			} else {
 				AmidstLogger.warn("invalid configuration");
 				dialogs.displayError("invalid configuration");
@@ -143,8 +144,8 @@ public class SeedSearcherWindow {
 	}
 
 	@CalledOnlyBy(AmidstThread.EDT)
-	private void seedFound(WorldSeed worldSeed, WorldType worldType) {
-		worldSwitcher.displayWorld(worldSeed, worldType);
+	private void seedFound(WorldOptions worldOptions) {
+		worldSwitcher.displayWorld(worldOptions);
 		updateGUI();
 	}
 

--- a/src/main/java/amidst/mojangapi/RunningLauncherProfile.java
+++ b/src/main/java/amidst/mojangapi/RunningLauncherProfile.java
@@ -13,8 +13,7 @@ import amidst.mojangapi.minecraftinterface.local.LocalMinecraftInterface;
 import amidst.mojangapi.minecraftinterface.local.LocalMinecraftInterfaceCreationException;
 import amidst.mojangapi.world.World;
 import amidst.mojangapi.world.WorldBuilder;
-import amidst.mojangapi.world.WorldSeed;
-import amidst.mojangapi.world.WorldType;
+import amidst.mojangapi.world.WorldOptions;
 
 @ThreadSafe
 public class RunningLauncherProfile {
@@ -63,11 +62,11 @@ public class RunningLauncherProfile {
 	 * one world at a time. Creating a new world will break all previously
 	 * created world objects.
 	 */
-	public synchronized World createWorldFromSeed(WorldSeed worldSeed, WorldType worldType)
+	public synchronized World createWorld(WorldOptions worldOptions)
 			throws IllegalStateException,
 			MinecraftInterfaceException {
 		if (currentWorld == null) {
-			currentWorld = worldBuilder.fromSeed(minecraftInterface, this::unlock, worldSeed, worldType);
+			currentWorld = worldBuilder.from(minecraftInterface, this::unlock, worldOptions);
 			return currentWorld;
 		} else {
 			throw new IllegalStateException(

--- a/src/main/java/amidst/mojangapi/world/WorldBuilder.java
+++ b/src/main/java/amidst/mojangapi/world/WorldBuilder.java
@@ -54,24 +54,23 @@ public class WorldBuilder {
 		this.seedHistoryLogger = seedHistoryLogger;
 	}
 
-	public World fromSeed(
+	public World from(
 			MinecraftInterface minecraftInterface,
 			Consumer<World> onDisposeWorld,
-			WorldSeed worldSeed,
-			WorldType worldType) throws MinecraftInterfaceException {
+			WorldOptions worldOptions) throws MinecraftInterfaceException {
 		BiomeDataOracle biomeDataOracle = new BiomeDataOracle(minecraftInterface);
 		VersionFeatures versionFeatures = DefaultVersionFeatures.create(minecraftInterface.getRecognisedVersion());
 		return create(
 				minecraftInterface,
 				onDisposeWorld,
-				worldSeed,
-				worldType,
-				"",
+				worldOptions.getWorldSeed(),
+				worldOptions.getWorldType(),
+				worldOptions.getGeneratorOptions(),
 				MovablePlayerList.dummy(),
 				versionFeatures,
 				biomeDataOracle,
 				new HeuristicWorldSpawnOracle(
-						worldSeed.getLong(),
+						worldOptions.getWorldSeed().getLong(),
 						biomeDataOracle,
 						versionFeatures.getValidBiomesForStructure_Spawn()));
 	}

--- a/src/main/java/amidst/mojangapi/world/WorldOptions.java
+++ b/src/main/java/amidst/mojangapi/world/WorldOptions.java
@@ -1,0 +1,41 @@
+package amidst.mojangapi.world;
+
+import amidst.documentation.Immutable;
+import amidst.mojangapi.file.SaveGame;
+
+@Immutable
+public class WorldOptions {
+	private final WorldSeed worldSeed;
+	private final WorldType worldType;
+	private final String genOptions;
+	
+	public WorldOptions(WorldSeed seed, WorldType type, String generatorOptions) {
+		worldSeed = seed;
+		worldType = type;
+		genOptions = generatorOptions;
+	}
+	
+	public WorldOptions(WorldSeed seed, WorldType type) {
+		this(seed, type, "");
+	}
+	
+	public WorldOptions withGeneratorOptions(String generatorOptions) {
+		return new WorldOptions(worldSeed, worldType, generatorOptions);
+	}
+	
+	public static WorldOptions fromSaveGame(SaveGame saveGame) {
+		return new WorldOptions(WorldSeed.fromSaveGame(saveGame.getSeed()), saveGame.getWorldType(), saveGame.getGeneratorOptions());
+	}
+	
+	public WorldSeed getWorldSeed() {
+		return worldSeed;
+	}
+	
+	public WorldType getWorldType() {
+		return worldType;
+	}
+	
+	public String getGeneratorOptions() {
+		return genOptions;
+	}
+}

--- a/src/test/java/amidst/mojangapi/mocking/FakeWorldBuilder.java
+++ b/src/test/java/amidst/mojangapi/mocking/FakeWorldBuilder.java
@@ -8,7 +8,6 @@ import amidst.mojangapi.minecraftinterface.MinecraftInterface;
 import amidst.mojangapi.minecraftinterface.MinecraftInterfaceException;
 import amidst.mojangapi.world.World;
 import amidst.mojangapi.world.WorldBuilder;
-import amidst.mojangapi.world.WorldSeed;
 import amidst.mojangapi.world.testworld.TestWorldDeclaration;
 import amidst.mojangapi.world.testworld.TestWorldEntryNames;
 import amidst.mojangapi.world.testworld.file.TestWorldDirectory;
@@ -34,11 +33,10 @@ public class FakeWorldBuilder {
 
 	public World createRealWorld(TestWorldDeclaration worldDeclaration, MinecraftInterface realMinecraftInterface)
 			throws MinecraftInterfaceException {
-		return builder.fromSeed(
+		return builder.from(
 				realMinecraftInterface,
 				NOOP,
-				worldDeclaration.getWorldSeed(),
-				worldDeclaration.getWorldType());
+				worldDeclaration.getWorldOptions());
 	}
 
 	public World createFakeWorld(TestWorldDirectory worldDeclaration) throws MinecraftInterfaceException {
@@ -59,11 +57,10 @@ public class FakeWorldBuilder {
 			WorldMetadataJson worldMetadata,
 			BiomeDataJson quarterBiomeData,
 			BiomeDataJson fullBiomeData) throws MinecraftInterfaceException {
-		return builder.fromSeed(
+		return builder.from(
 				createFakeMinecraftInterface(worldMetadata, quarterBiomeData, fullBiomeData),
 				NOOP,
-				WorldSeed.fromUserInput(worldMetadata.getSeed() + ""),
-				worldMetadata.getWorldType());
+				worldMetadata.intoWorldOptions());
 	}
 
 	private static FakeMinecraftInterface createFakeMinecraftInterface(

--- a/src/test/java/amidst/mojangapi/world/testworld/TestWorldDeclaration.java
+++ b/src/test/java/amidst/mojangapi/world/testworld/TestWorldDeclaration.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import amidst.documentation.Immutable;
 import amidst.mojangapi.minecraftinterface.RecognisedVersion;
+import amidst.mojangapi.world.WorldOptions;
 import amidst.mojangapi.world.WorldSeed;
 import amidst.mojangapi.world.WorldType;
 
@@ -67,8 +68,7 @@ public enum TestWorldDeclaration {
 	private static final String ZIP_FILE_EXTENSION = ".zip";
 
 	private final RecognisedVersion recognisedVersion;
-	private final WorldSeed worldSeed;
-	private final WorldType worldType;
+	private final WorldOptions worldOptions;
 	private final List<String> supportedEntryNames;
 	private final File directory;
 	private final String directoryString;
@@ -79,8 +79,8 @@ public enum TestWorldDeclaration {
 			WorldType worldType,
 			String... supported) {
 		this.recognisedVersion = recognisedVersion;
-		this.worldSeed = WorldSeed.fromUserInput(seed);
-		this.worldType = worldType;
+		WorldSeed worldSeed = WorldSeed.fromUserInput(seed);
+		this.worldOptions = new WorldOptions(worldSeed, worldType);
 		this.supportedEntryNames = Collections.unmodifiableList(Arrays.asList(supported));
 		this.directory = Paths.get(
 				"src",
@@ -100,12 +100,8 @@ public enum TestWorldDeclaration {
 		return recognisedVersion;
 	}
 
-	public WorldSeed getWorldSeed() {
-		return worldSeed;
-	}
-
-	public WorldType getWorldType() {
-		return worldType;
+	public WorldOptions getWorldOptions() {
+		return worldOptions;
 	}
 
 	public boolean isSupported(String name) {

--- a/src/test/java/amidst/mojangapi/world/testworld/storage/json/WorldMetadataJson.java
+++ b/src/test/java/amidst/mojangapi/world/testworld/storage/json/WorldMetadataJson.java
@@ -4,6 +4,8 @@ import amidst.documentation.GsonConstructor;
 import amidst.documentation.Immutable;
 import amidst.mojangapi.minecraftinterface.RecognisedVersion;
 import amidst.mojangapi.world.World;
+import amidst.mojangapi.world.WorldOptions;
+import amidst.mojangapi.world.WorldSeed;
 import amidst.mojangapi.world.WorldType;
 
 @Immutable
@@ -39,5 +41,9 @@ public class WorldMetadataJson {
 
 	public WorldType getWorldType() {
 		return worldType;
+	}
+
+	public WorldOptions intoWorldOptions() {
+		return new WorldOptions(WorldSeed.fromUserInput(seed + ""), worldType);
 	}
 }


### PR DESCRIPTION
Create the WorldOptions class to regroup WorldSeed, WorldType and the configuration string into a single object.

Should we modify the WorldType selection dialog to allow the user to also provide a configuration string to use for all worlds, and if so, should this be included in this PR ?