### PR TITLE
Display correct name and version for Windows default profiles

### DIFF
--- a/src/main/java/amidst/mojangapi/file/json/launcherprofiles/LauncherProfileJson.java
+++ b/src/main/java/amidst/mojangapi/file/json/launcherprofiles/LauncherProfileJson.java
@@ -1,6 +1,5 @@
 package amidst.mojangapi.file.json.launcherprofiles;
 
-import java.util.Arrays;
 import java.util.List;
 
 import amidst.documentation.GsonConstructor;
@@ -9,10 +8,12 @@ import amidst.mojangapi.file.json.ReleaseType;
 
 @Immutable
 public class LauncherProfileJson {
+	
 	/**
-	 * Some Minecraft installations have a profile with the key "(Default)" and
-	 * no properties in the actual profile object. The JSON looks like this:
+	 * Some Minecraft installations using the legacy launcher have a profile
+	 * with the key "(Default)" and no properties in the actual profile object.
 	 * 
+	 * The JSON looks like this:
 	 * "(Default)": {},
 	 * 
 	 * This profile has the name null. Also, it cannot be deleted from the
@@ -23,14 +24,16 @@ public class LauncherProfileJson {
 	private volatile String name = "";
 	private volatile String lastVersionId;
 	private volatile String gameDir;
-	private volatile List<ReleaseType> allowedReleaseTypes = Arrays.asList(ReleaseType.RELEASE);
+	private volatile List<ReleaseType> allowedReleaseTypes = ProfileType.LATEST_RELEASE.getAllowedReleaseTypes().get();
+	
+	private volatile ProfileType type = ProfileType.LEGACY;
 
 	@GsonConstructor
 	public LauncherProfileJson() {
 	}
 
 	public String getName() {
-		return name;
+		return type.getDefaultName().orElse(name);
 	}
 
 	public String getLastVersionId() {
@@ -42,6 +45,6 @@ public class LauncherProfileJson {
 	}
 
 	public List<ReleaseType> getAllowedReleaseTypes() {
-		return allowedReleaseTypes;
+		return type.getAllowedReleaseTypes().orElse(allowedReleaseTypes);
 	}
 }

--- a/src/main/java/amidst/mojangapi/file/json/launcherprofiles/ProfileType.java
+++ b/src/main/java/amidst/mojangapi/file/json/launcherprofiles/ProfileType.java
@@ -1,0 +1,51 @@
+package amidst.mojangapi.file.json.launcherprofiles;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import com.google.gson.annotations.SerializedName;
+
+import amidst.documentation.Immutable;
+import amidst.mojangapi.file.json.ReleaseType;
+
+/** Profiles types, as used in the new profile format (2) used by the Windows launcher.
+ *  A typical installation has to profiles created by default, of type
+ *  LATEST_RELEASE and LATEST_SNAPSHOT, and their names can't be changed.
+ *  
+ *  The LEGACY profile represents a profile in the format used by the old launcher (1).
+ */
+@Immutable
+public enum ProfileType {
+	@SerializedName("latest-release")
+	LATEST_RELEASE("Latest version", ReleaseType.RELEASE),
+	@SerializedName("latest-snapshot")
+	LATEST_SNAPSHOT("Latest snapshot", ReleaseType.RELEASE, ReleaseType.SNAPSHOT),
+	@SerializedName("custom")
+	CUSTOM(null),
+	@SerializedName("")
+	LEGACY(null),
+	;
+	
+	private Optional<String> defaultName;
+	private Optional<List<ReleaseType>> allowedReleaseTypes;
+	
+	private ProfileType(String defaultName, ReleaseType... releaseTypes) {
+		this.defaultName = Optional.ofNullable(defaultName);
+		if(releaseTypes.length > 0) {
+			this.allowedReleaseTypes = Optional.of(Collections.unmodifiableList(Arrays.asList(releaseTypes)));
+		} else {
+			this.allowedReleaseTypes = Optional.empty();
+		}
+	}
+	
+	public Optional<String> getDefaultName() {
+		return defaultName;
+	}
+	
+	public Optional<List<ReleaseType>> getAllowedReleaseTypes() {
+		return allowedReleaseTypes;
+	}
+	
+}


### PR DESCRIPTION
Add support for the default profiles used by the Windows launcher : 
 - Latest version: `"type": "latest-release"`, equivalent to the "bugged" default profile of the legacy launcher
- Latest snapshot: `"type": "latest-snapshot"`, this was improperly detected as the legacy default profile before

This fixes #377.