### PR TITLE
Fix some false negative villages

### DIFF
--- a/src/main/java/amidst/mojangapi/world/WorldBuilder.java
+++ b/src/main/java/amidst/mojangapi/world/WorldBuilder.java
@@ -135,7 +135,8 @@ public class WorldBuilder {
 						new VillageLocationChecker(
 								seed,
 								biomeDataOracle,
-								versionFeatures.getValidBiomesForStructure_Village()),
+								versionFeatures.getValidBiomesForStructure_Village(),
+								versionFeatures.getDoComplexVillageCheck()),
 						new ImmutableWorldIconTypeProvider(DefaultWorldIconTypes.VILLAGE),
 						Dimension.OVERWORLD,
 						false),

--- a/src/main/java/amidst/mojangapi/world/icon/locationchecker/VillageLocationChecker.java
+++ b/src/main/java/amidst/mojangapi/world/icon/locationchecker/VillageLocationChecker.java
@@ -16,17 +16,28 @@ public class VillageLocationChecker extends AllValidLocationChecker {
 	private static final boolean USE_TWO_VALUES_FOR_UPDATE = false;
 	private static final int STRUCTURE_SIZE = 0;
 
-	public VillageLocationChecker(long seed, BiomeDataOracle biomeDataOracle, List<Biome> validBiomesForStructure) {
-		super(
-				new StructureAlgorithm(
-						seed,
-						MAGIC_NUMBER_FOR_SEED_1,
-						MAGIC_NUMBER_FOR_SEED_2,
-						MAGIC_NUMBER_FOR_SEED_3,
-						MAX_DISTANCE_BETWEEN_SCATTERED_FEATURES,
-						MIN_DISTANCE_BETWEEN_SCATTERED_FEATURES,
-						USE_TWO_VALUES_FOR_UPDATE),
-				new StructureBiomeLocationChecker(biomeDataOracle, STRUCTURE_SIZE, validBiomesForStructure),
-				new VillageAlgorithm(biomeDataOracle, validBiomesForStructure));
+	public VillageLocationChecker(
+			long seed, BiomeDataOracle biomeDataOracle, List<Biome> validBiomesForStructure, boolean doComplexVillageCheck) {
+		super(getLocationCheckers(seed, biomeDataOracle, validBiomesForStructure, doComplexVillageCheck));
+	}
+	
+	private static LocationChecker[] getLocationCheckers(
+			long seed, BiomeDataOracle biomeDataOracle, List<Biome> validBiomesForStructure, boolean doComplexVillageCheck) {
+		LocationChecker base = new StructureAlgorithm(
+				seed,
+				MAGIC_NUMBER_FOR_SEED_1,
+				MAGIC_NUMBER_FOR_SEED_2,
+				MAGIC_NUMBER_FOR_SEED_3,
+				MAX_DISTANCE_BETWEEN_SCATTERED_FEATURES,
+				MIN_DISTANCE_BETWEEN_SCATTERED_FEATURES,
+				USE_TWO_VALUES_FOR_UPDATE
+			);
+		LocationChecker biome = new StructureBiomeLocationChecker(biomeDataOracle, STRUCTURE_SIZE, validBiomesForStructure);
+
+		if(doComplexVillageCheck) {
+			return new LocationChecker[] { base, biome, new VillageAlgorithm(biomeDataOracle, validBiomesForStructure) };
+		} else {
+			return new LocationChecker[] { base, biome };
+		}
 	}
 }

--- a/src/main/java/amidst/mojangapi/world/versionfeatures/DefaultVersionFeatures.java
+++ b/src/main/java/amidst/mojangapi/world/versionfeatures/DefaultVersionFeatures.java
@@ -31,6 +31,7 @@ public enum DefaultVersionFeatures {
 				INSTANCE.validBiomesAtMiddleOfChunk_Stronghold.getValue(version),
 				INSTANCE.strongholdProducerFactory.getValue(version),
 				INSTANCE.validBiomesForStructure_Village.getValue(version),
+				INSTANCE.doComplexVillageCheck.getValue(version),
 				INSTANCE.validBiomesAtMiddleOfChunk_DesertTemple.getValue(version),
 				INSTANCE.validBiomesAtMiddleOfChunk_Igloo.getValue(version),
 				INSTANCE.validBiomesAtMiddleOfChunk_JungleTemple.getValue(version),
@@ -56,6 +57,7 @@ public enum DefaultVersionFeatures {
 	private final VersionFeature<List<Biome>> validBiomesAtMiddleOfChunk_Stronghold;
 	private final VersionFeature<TriFunction<Long, BiomeDataOracle, List<Biome>, StrongholdProducer_Base>> strongholdProducerFactory;
 	private final VersionFeature<List<Biome>> validBiomesForStructure_Village;
+	private final VersionFeature<Boolean> doComplexVillageCheck;
 	private final VersionFeature<List<Biome>> validBiomesAtMiddleOfChunk_DesertTemple;
 	private final VersionFeature<List<Biome>> validBiomesAtMiddleOfChunk_Igloo;
 	private final VersionFeature<List<Biome>> validBiomesAtMiddleOfChunk_JungleTemple;
@@ -153,8 +155,13 @@ public enum DefaultVersionFeatures {
 						Biome.savanna
 				).sinceExtend(RecognisedVersion._16w20a,
 						Biome.taiga
-				)
-				.construct();
+				).construct();
+		this.doComplexVillageCheck = VersionFeature.<Boolean> builder()
+				.init(
+						true
+				).since(RecognisedVersion._16w20a,
+						false
+				).construct();
 		this.validBiomesAtMiddleOfChunk_DesertTemple = VersionFeature.<Biome> listBuilder()
 				.init(
 						Biome.desert,

--- a/src/main/java/amidst/mojangapi/world/versionfeatures/VersionFeatures.java
+++ b/src/main/java/amidst/mojangapi/world/versionfeatures/VersionFeatures.java
@@ -17,6 +17,7 @@ public class VersionFeatures {
 	private final List<Biome> validBiomesAtMiddleOfChunk_Stronghold;
 	private final TriFunction<Long, BiomeDataOracle, List<Biome>, StrongholdProducer_Base> strongholdProducerFactory;
 	private final List<Biome> validBiomesForStructure_Village;
+	private final Boolean doComplexVillageCheck;
 	private final List<Biome> validBiomesAtMiddleOfChunk_DesertTemple;
 	private final List<Biome> validBiomesAtMiddleOfChunk_Igloo;
 	private final List<Biome> validBiomesAtMiddleOfChunk_JungleTemple;
@@ -42,6 +43,7 @@ public class VersionFeatures {
 			List<Biome> validBiomesAtMiddleOfChunk_Stronghold,
 			TriFunction<Long, BiomeDataOracle, List<Biome>, StrongholdProducer_Base> strongholdProducerFactory,
 			List<Biome> validBiomesForStructure_Village,
+			Boolean doComplexVillageCheck,
 			List<Biome> validBiomesAtMiddleOfChunk_DesertTemple,
 			List<Biome> validBiomesAtMiddleOfChunk_Igloo,
 			List<Biome> validBiomesAtMiddleOfChunk_JungleTemple,
@@ -65,6 +67,7 @@ public class VersionFeatures {
 		this.validBiomesAtMiddleOfChunk_Stronghold = validBiomesAtMiddleOfChunk_Stronghold;
 		this.strongholdProducerFactory = strongholdProducerFactory;
 		this.validBiomesForStructure_Village = validBiomesForStructure_Village;
+		this.doComplexVillageCheck = doComplexVillageCheck;
 		this.validBiomesAtMiddleOfChunk_DesertTemple = validBiomesAtMiddleOfChunk_DesertTemple;
 		this.validBiomesAtMiddleOfChunk_Igloo = validBiomesAtMiddleOfChunk_Igloo;
 		this.validBiomesAtMiddleOfChunk_JungleTemple = validBiomesAtMiddleOfChunk_JungleTemple;
@@ -103,6 +106,10 @@ public class VersionFeatures {
 
 	public List<Biome> getValidBiomesForStructure_Village() {
 		return validBiomesForStructure_Village;
+	}
+	
+	public Boolean getDoComplexVillageCheck() {
+		return doComplexVillageCheck;
 	}
 
 	public List<Biome> getValidBiomesAtMiddleOfChunk_DesertTemple() {


### PR DESCRIPTION
Since Minecraft 16w20a, villages can spread into invalid biomes, which means that villages rejected by the [`VillageAlgorithm`](https://github.com/toolbox4minecraft/amidst/blob/master/src/main/java/amidst/mojangapi/world/icon/locationchecker/VillageAlgorithm.java) should be accepted in 16w20a or higher.

This PR disable the `VillageAlgorithm` check accordingly, and all 3 villages mentioned in #117 now correctly appear in Amidst.