### PR TITLE
Use openjdk instead of oraclejdk for Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-- oraclejdk8
+- openjdk8
 addons:
   apt:
     packages:


### PR DESCRIPTION
`oraclejdk8` is no longer supported by Travis CI.