### PR TITLE
Add -seed command line argument

### DIFF
--- a/src/main/java/amidst/CommandLineParameters.java
+++ b/src/main/java/amidst/CommandLineParameters.java
@@ -28,7 +28,10 @@ public class CommandLineParameters {
 
 	@Option(name = "-log",                    usage = "location of the log file",                            metaVar = "<file>")
 	public volatile String logFile;
-	
+
+	@Option(name = "-seed",                   usage = "initial seed to use",                                         metaVar = "<string>")
+	public volatile String initialSeed;
+
 	@Option(name = "-help",                   usage = "print usage information")
 	public volatile boolean printHelp;
 

--- a/src/main/java/amidst/CommandLineParameters.java
+++ b/src/main/java/amidst/CommandLineParameters.java
@@ -29,8 +29,11 @@ public class CommandLineParameters {
 	@Option(name = "-log",                    usage = "location of the log file",                            metaVar = "<file>")
 	public volatile String logFile;
 
-	@Option(name = "-seed",                   usage = "initial seed to use",                                         metaVar = "<string>")
+	@Option(name = "-seed",                   usage = "initial seed to use",                                 metaVar = "<string>")
 	public volatile String initialSeed;
+
+	@Option(name = "-world-type",             usage = "world type for the initial seed",                     metaVar = "<string>")
+	public volatile String initialWorldType;
 
 	@Option(name = "-help",                   usage = "print usage information")
 	public volatile boolean printHelp;

--- a/src/main/java/amidst/PerApplicationInjector.java
+++ b/src/main/java/amidst/PerApplicationInjector.java
@@ -67,7 +67,7 @@ public class PerApplicationInjector {
 		this.preferredLauncherProfile = minecraftInstallation
 				.tryReadLauncherProfile(parameters.minecraftJarFile, parameters.minecraftJsonFile);
 		this.worldBuilder = new WorldBuilder(playerInformationProvider, seedHistoryLogger);
-		this.launcherProfileRunner = new LauncherProfileRunner(worldBuilder);
+		this.launcherProfileRunner = new LauncherProfileRunner(worldBuilder, parameters.initialSeed);
 		this.biomeProfileDirectory = BiomeProfileDirectory.create(parameters.biomeProfilesDirectory);
 		this.threadMaster = new ThreadMaster();
 		this.versionListProvider = VersionListProvider

--- a/src/main/java/amidst/PerApplicationInjector.java
+++ b/src/main/java/amidst/PerApplicationInjector.java
@@ -67,7 +67,7 @@ public class PerApplicationInjector {
 		this.preferredLauncherProfile = minecraftInstallation
 				.tryReadLauncherProfile(parameters.minecraftJarFile, parameters.minecraftJsonFile);
 		this.worldBuilder = new WorldBuilder(playerInformationProvider, seedHistoryLogger);
-		this.launcherProfileRunner = new LauncherProfileRunner(worldBuilder, parameters.initialSeed);
+		this.launcherProfileRunner = new LauncherProfileRunner(worldBuilder, parameters.initialSeed, parameters.initialWorldType);
 		this.biomeProfileDirectory = BiomeProfileDirectory.create(parameters.biomeProfilesDirectory);
 		this.threadMaster = new ThreadMaster();
 		this.versionListProvider = VersionListProvider

--- a/src/main/java/amidst/gui/main/MainWindow.java
+++ b/src/main/java/amidst/gui/main/MainWindow.java
@@ -38,7 +38,7 @@ public class MainWindow {
 
 	@CalledOnlyBy(AmidstThread.EDT)
 	public void initializeFrame(AmidstMetaData metadata, String versionString, Actions actions, AmidstMenu menuBar,
-				 String initialSeed) {
+				 WorldOptions initialWorldOptions) {
 		frame.setSize(1000, 800);
 		frame.setIconImages(metadata.getIcons());
 		frame.setTitle(versionString);
@@ -52,9 +52,9 @@ public class MainWindow {
 		});
 		frame.setVisible(true);
 		worldSwitcher.clearWorld();
-		if (initialSeed != null) {
-			AmidstLogger.info("Setting initial seed to " + initialSeed);
-			worldSwitcher.displayWorld(new WorldOptions(WorldSeed.fromUserInput(initialSeed), WorldType.DEFAULT));
+		if (initialWorldOptions != null) {
+			AmidstLogger.info("Setting initial world options to [" + initialWorldOptions.getWorldSeed().getLabel() + ", World Type: " + initialWorldOptions.getWorldType() + "]");
+			worldSwitcher.displayWorld(initialWorldOptions);
 		}
 	}
 	

--- a/src/main/java/amidst/gui/main/MainWindow.java
+++ b/src/main/java/amidst/gui/main/MainWindow.java
@@ -15,6 +15,10 @@ import amidst.documentation.NotThreadSafe;
 import amidst.gui.main.menu.AmidstMenu;
 import amidst.gui.main.viewer.ViewerFacade;
 import amidst.gui.seedsearcher.SeedSearcherWindow;
+import amidst.logging.AmidstLogger;
+import amidst.mojangapi.world.WorldOptions;
+import amidst.mojangapi.world.WorldSeed;
+import amidst.mojangapi.world.WorldType;
 
 @NotThreadSafe
 public class MainWindow {
@@ -33,7 +37,8 @@ public class MainWindow {
 	}
 
 	@CalledOnlyBy(AmidstThread.EDT)
-	public void initializeFrame(AmidstMetaData metadata, String versionString, Actions actions, AmidstMenu menuBar) {
+	public void initializeFrame(AmidstMetaData metadata, String versionString, Actions actions, AmidstMenu menuBar,
+				 String initialSeed) {
 		frame.setSize(1000, 800);
 		frame.setIconImages(metadata.getIcons());
 		frame.setTitle(versionString);
@@ -47,6 +52,10 @@ public class MainWindow {
 		});
 		frame.setVisible(true);
 		worldSwitcher.clearWorld();
+		if (initialSeed != null) {
+			AmidstLogger.info("Setting initial seed to " + initialSeed);
+			worldSwitcher.displayWorld(new WorldOptions(WorldSeed.fromUserInput(initialSeed), WorldType.DEFAULT));
+		}
 	}
 	
 	public WorldSwitcher getWorldSwitcher() {

--- a/src/main/java/amidst/gui/main/PerMainWindowInjector.java
+++ b/src/main/java/amidst/gui/main/PerMainWindowInjector.java
@@ -98,7 +98,7 @@ public class PerMainWindowInjector {
 				settings.biomeProfileSelection);
 		this.menuBar = new AmidstMenuBuilder(settings, actions, biomeProfileDirectory).construct();
 		this.mainWindow = new MainWindow(frame, worldSwitcher, viewerFacadeReference::get, seedSearcherWindow);
-		this.mainWindow.initializeFrame(metadata, versionString, actions, menuBar);
+		this.mainWindow.initializeFrame(metadata, versionString, actions, menuBar, runningLauncherProfile.getInitialSeed());
 	}
 
 	@CalledOnlyBy(AmidstThread.EDT)

--- a/src/main/java/amidst/gui/main/PerMainWindowInjector.java
+++ b/src/main/java/amidst/gui/main/PerMainWindowInjector.java
@@ -98,7 +98,7 @@ public class PerMainWindowInjector {
 				settings.biomeProfileSelection);
 		this.menuBar = new AmidstMenuBuilder(settings, actions, biomeProfileDirectory).construct();
 		this.mainWindow = new MainWindow(frame, worldSwitcher, viewerFacadeReference::get, seedSearcherWindow);
-		this.mainWindow.initializeFrame(metadata, versionString, actions, menuBar, runningLauncherProfile.getInitialSeed());
+		this.mainWindow.initializeFrame(metadata, versionString, actions, menuBar, runningLauncherProfile.getInitialWorldOptions());
 	}
 
 	@CalledOnlyBy(AmidstThread.EDT)

--- a/src/main/java/amidst/mojangapi/LauncherProfileRunner.java
+++ b/src/main/java/amidst/mojangapi/LauncherProfileRunner.java
@@ -8,12 +8,14 @@ import amidst.mojangapi.world.WorldBuilder;
 @Immutable
 public class LauncherProfileRunner {
 	private final WorldBuilder worldBuilder;
+	private String initialSeed;
 
-	public LauncherProfileRunner(WorldBuilder worldBuilder) {
+	public LauncherProfileRunner(WorldBuilder worldBuilder, String initialSeed) {
 		this.worldBuilder = worldBuilder;
+		this.initialSeed = initialSeed;
 	}
 
 	public RunningLauncherProfile run(LauncherProfile launcherProfile) throws MinecraftInterfaceCreationException {
-		return RunningLauncherProfile.from(worldBuilder, launcherProfile);
+		return RunningLauncherProfile.from(worldBuilder, launcherProfile, initialSeed);
 	}
 }

--- a/src/main/java/amidst/mojangapi/LauncherProfileRunner.java
+++ b/src/main/java/amidst/mojangapi/LauncherProfileRunner.java
@@ -1,21 +1,44 @@
 package amidst.mojangapi;
 
 import amidst.documentation.Immutable;
+import amidst.logging.AmidstLogger;
 import amidst.mojangapi.file.LauncherProfile;
 import amidst.mojangapi.minecraftinterface.MinecraftInterfaceCreationException;
 import amidst.mojangapi.world.WorldBuilder;
+import amidst.mojangapi.world.WorldOptions;
+import amidst.mojangapi.world.WorldSeed;
+import amidst.mojangapi.world.WorldType;
 
 @Immutable
 public class LauncherProfileRunner {
 	private final WorldBuilder worldBuilder;
-	private String initialSeed;
+	private WorldOptions initialWorldOptions;
 
-	public LauncherProfileRunner(WorldBuilder worldBuilder, String initialSeed) {
+	public LauncherProfileRunner(WorldBuilder worldBuilder, String initialSeed, String initialWorldType) {
 		this.worldBuilder = worldBuilder;
-		this.initialSeed = initialSeed;
+		this.initialWorldOptions = getInitialWorldOptions(initialSeed, initialWorldType);
+	}
+
+	private WorldOptions getInitialWorldOptions(String initialSeed, String initialWorldType) {
+		if (initialSeed == null || initialSeed.isEmpty()) {
+			if (initialWorldType != null) {
+				AmidstLogger.warn("-world-type has no meaning without -seed");
+			}
+			return null;
+		}
+
+		WorldType worldType = WorldType.DEFAULT;
+		if (initialWorldType != null && !initialWorldType.isEmpty()) {
+			worldType = WorldType.findInstance(initialWorldType);
+			if (worldType == null) {
+				AmidstLogger.warn("Invalid value for -world-type: '" + initialWorldType + "', falling back to default");
+				worldType = WorldType.DEFAULT;
+			}
+		}
+		return new WorldOptions(WorldSeed.fromUserInput(initialSeed), worldType);
 	}
 
 	public RunningLauncherProfile run(LauncherProfile launcherProfile) throws MinecraftInterfaceCreationException {
-		return RunningLauncherProfile.from(worldBuilder, launcherProfile, initialSeed);
+		return RunningLauncherProfile.from(worldBuilder, launcherProfile, initialWorldOptions);
 	}
 }

--- a/src/main/java/amidst/mojangapi/RunningLauncherProfile.java
+++ b/src/main/java/amidst/mojangapi/RunningLauncherProfile.java
@@ -17,37 +17,37 @@ import amidst.mojangapi.world.WorldOptions;
 
 @ThreadSafe
 public class RunningLauncherProfile {
-	public static RunningLauncherProfile from(WorldBuilder worldBuilder, LauncherProfile launcherProfile, String initialSeed)
+	public static RunningLauncherProfile from(WorldBuilder worldBuilder, LauncherProfile launcherProfile, WorldOptions initialWorldOptions)
 			throws MinecraftInterfaceCreationException {
 		return new RunningLauncherProfile(
 				worldBuilder,
 				launcherProfile,
-				new LoggingMinecraftInterface(MinecraftInterfaces.fromLocalProfile(launcherProfile)), initialSeed);
+				new LoggingMinecraftInterface(MinecraftInterfaces.fromLocalProfile(launcherProfile)), initialWorldOptions);
 	}
 
 	private final WorldBuilder worldBuilder;
 	private final LauncherProfile launcherProfile;
 	private final MinecraftInterface minecraftInterface;
 	private volatile World currentWorld = null;
-	private final String initialSeed;
+	private final WorldOptions initialWorldOptions;
 
 	public RunningLauncherProfile(
 			WorldBuilder worldBuilder,
 			LauncherProfile launcherProfile,
 			MinecraftInterface minecraftInterface,
-			String initialSeed) {
+			WorldOptions initialWorldOptions) {
 		this.worldBuilder = worldBuilder;
 		this.launcherProfile = launcherProfile;
 		this.minecraftInterface = minecraftInterface;
-		this.initialSeed = initialSeed;
+		this.initialWorldOptions = initialWorldOptions;
 	}
 
 	public LauncherProfile getLauncherProfile() {
 		return launcherProfile;
 	}
 
-	public String getInitialSeed() {
-		return initialSeed;
+	public WorldOptions getInitialWorldOptions() {
+		return initialWorldOptions;
 	}
 
 	public RecognisedVersion getRecognisedVersion() {

--- a/src/main/java/amidst/mojangapi/RunningLauncherProfile.java
+++ b/src/main/java/amidst/mojangapi/RunningLauncherProfile.java
@@ -17,30 +17,37 @@ import amidst.mojangapi.world.WorldOptions;
 
 @ThreadSafe
 public class RunningLauncherProfile {
-	public static RunningLauncherProfile from(WorldBuilder worldBuilder, LauncherProfile launcherProfile)
+	public static RunningLauncherProfile from(WorldBuilder worldBuilder, LauncherProfile launcherProfile, String initialSeed)
 			throws MinecraftInterfaceCreationException {
 		return new RunningLauncherProfile(
 				worldBuilder,
 				launcherProfile,
-				new LoggingMinecraftInterface(MinecraftInterfaces.fromLocalProfile(launcherProfile)));
+				new LoggingMinecraftInterface(MinecraftInterfaces.fromLocalProfile(launcherProfile)), initialSeed);
 	}
 
 	private final WorldBuilder worldBuilder;
 	private final LauncherProfile launcherProfile;
 	private final MinecraftInterface minecraftInterface;
 	private volatile World currentWorld = null;
+	private final String initialSeed;
 
 	public RunningLauncherProfile(
 			WorldBuilder worldBuilder,
 			LauncherProfile launcherProfile,
-			MinecraftInterface minecraftInterface) {
+			MinecraftInterface minecraftInterface,
+			String initialSeed) {
 		this.worldBuilder = worldBuilder;
 		this.launcherProfile = launcherProfile;
 		this.minecraftInterface = minecraftInterface;
+		this.initialSeed = initialSeed;
 	}
 
 	public LauncherProfile getLauncherProfile() {
 		return launcherProfile;
+	}
+
+	public String getInitialSeed() {
+		return initialSeed;
 	}
 
 	public RecognisedVersion getRecognisedVersion() {
@@ -49,7 +56,7 @@ public class RunningLauncherProfile {
 
 	public RunningLauncherProfile createSilentPlayerlessCopy() {
 		try {
-			return RunningLauncherProfile.from(WorldBuilder.createSilentPlayerless(), launcherProfile);
+			return RunningLauncherProfile.from(WorldBuilder.createSilentPlayerless(), launcherProfile, null);
 		} catch (MinecraftInterfaceCreationException e) {
 			// This will not happen normally, because we already successfully
 			// created the same LocalMinecraftInterface once before.

--- a/src/main/java/amidst/mojangapi/world/WorldType.java
+++ b/src/main/java/amidst/mojangapi/world/WorldType.java
@@ -60,7 +60,7 @@ public enum WorldType {
 		}
 	}
 
-	private static WorldType findInstance(String nameOrValue) {
+	public static WorldType findInstance(String nameOrValue) {
 		for (WorldType worldType : values()) {
 			if (worldType.name.equalsIgnoreCase(nameOrValue)
 					|| worldType.symbolicFieldName.equalsIgnoreCase(nameOrValue)) {

--- a/src/test/java/amidst/devtools/WorldGenerationBencher.java
+++ b/src/test/java/amidst/devtools/WorldGenerationBencher.java
@@ -87,7 +87,8 @@ public class WorldGenerationBencher {
 			profile = new RunningLauncherProfile(
 					WorldBuilder.createSilentPlayerless(),
 					launcherProfile,
-					new BenchmarkingMinecraftInterface(MinecraftInterfaces.fromLocalProfile(launcherProfile), records));
+					new BenchmarkingMinecraftInterface(MinecraftInterfaces.fromLocalProfile(launcherProfile), records),
+					null);
 		} catch (FormatException | IOException | MinecraftInterfaceCreationException e) {
 			failed.add(version);
 			return;


### PR DESCRIPTION
Add -seed command line argument to start Amidst with a particular world seed selected. This implements feature #461.

I've tried my best to follow https://github.com/toolbox4minecraft/amidst/wiki/Supporting-the-Development. I have announced my intention in #461, unfortunately I have not received any response from the maintainers. :-( If this PR is not accepted, please let me know what I need to fix rather than just close it outright.

