### PR TITLE
Add -profile as a CLI option for easier selection of profile.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,9 @@
 *.ear
 
 # IntelliJ IDEA project files #
-./AMIDST.eml
-./AMIDST.iml
-./.idea/*
+/AMIDST.eml
+/AMIDST.iml
+/.idea/*
 /bin
 /dist
 /logs

--- a/src/main/java/amidst/CommandLineParameters.java
+++ b/src/main/java/amidst/CommandLineParameters.java
@@ -14,11 +14,14 @@ public class CommandLineParameters {
 	@Option(name = "-mcpath",                 usage = "location of the '.minecraft' directory.",             metaVar = "<directory>")
 	public volatile String dotMinecraftDirectory;
 
-	@Option(name = "-mcjar",                  usage = "location of the minecraft jar file",                  metaVar = "<file>",       depends = { "-mcjson" })
+	@Option(name = "-mcjar",                  usage = "location of the minecraft jar file",                  metaVar = "<file>",       depends = { "-mcjson" },   forbids = { "-profile" })
 	public volatile String minecraftJarFile;
 	
-	@Option(name = "-mcjson",                 usage = "location of the minecraft json file",                 metaVar = "<file>",       depends = { "-mcjar" })
+	@Option(name = "-mcjson",                 usage = "location of the minecraft json file",                 metaVar = "<file>",       depends = { "-mcjar" },    forbids = { "-profile" })
 	public volatile String minecraftJsonFile;
+
+	@Option(name = "-profile",                usage = "name of profile to select",                           metaVar = "<name>",       forbids = { "-mcjar", "-mcjson" })
+	public volatile String profileName;
 
 	@Option(name = "-biome-profiles",         usage = "location of the biome profile directory",             metaVar = "<directory>")
 	public volatile String biomeProfilesDirectory;

--- a/src/main/java/amidst/PerApplicationInjector.java
+++ b/src/main/java/amidst/PerApplicationInjector.java
@@ -64,8 +64,10 @@ public class PerApplicationInjector {
 		this.seedHistoryLogger = SeedHistoryLogger.from(parameters.seedHistoryFile);
 		this.minecraftInstallation = MinecraftInstallation
 				.newLocalMinecraftInstallation(parameters.dotMinecraftDirectory);
-		this.preferredLauncherProfile = minecraftInstallation
-				.tryReadLauncherProfile(parameters.minecraftJarFile, parameters.minecraftJsonFile);
+		this.preferredLauncherProfile = minecraftInstallation.tryReadLauncherProfile(
+				parameters.minecraftJarFile,
+				parameters.minecraftJsonFile,
+				parameters.profileName);
 		this.worldBuilder = new WorldBuilder(playerInformationProvider, seedHistoryLogger);
 		this.launcherProfileRunner = new LauncherProfileRunner(worldBuilder);
 		this.biomeProfileDirectory = BiomeProfileDirectory.create(parameters.biomeProfilesDirectory);


### PR DESCRIPTION
This is the second part of #461. This patch adds a -profile command line option. While technically equivalent to using -mcjson and -mcjar, this makes for a simpler user interface. You can just specify "-profile 1.32.2" (if that's what your profile is called) to select it, instead of looking up the correct path to your minecraft directory and the corresponding version json and jar files.

-profile cannot be used together with -mcjson and -mcjar. I'm limiting the use to local profiles (I don't fully understand the remote profiles, and I don't want to rely on remote query to properly parse command line options), but as far as I understand, this is the same limitation that using -mcjar and -mcjson sets.

I also added a patch for .gitignore. It was bugging me that it didn't work correctly with IntelliJ IDEA.