### PR TITLE
Rewrite the current LocalMinecraftInterface for performance gains

### DIFF
--- a/src/main/java/amidst/clazz/real/RealClass.java
+++ b/src/main/java/amidst/clazz/real/RealClass.java
@@ -1,6 +1,7 @@
 package amidst.clazz.real;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -46,6 +47,7 @@ public class RealClass {
 	private final List<Float> floatConstants;
 	private final List<Double> doubleConstants;
 	private final List<Long> longConstants;
+	private final List<Integer> intConstants;
 	private final List<Integer> stringIndices;
 	private final List<ReferenceIndex> methodIndices;
 
@@ -68,6 +70,7 @@ public class RealClass {
 			List<Float> floatConstants,
 			List<Double> doubleConstants,
 			List<Long> longConstants,
+			List<Integer> intConstants,
 			List<Integer> stringIndices,
 			List<ReferenceIndex> methodIndices,
 			int accessFlags,
@@ -86,6 +89,7 @@ public class RealClass {
 		this.floatConstants = floatConstants;
 		this.doubleConstants = doubleConstants;
 		this.longConstants = longConstants;
+		this.intConstants = intConstants;
 		this.stringIndices = stringIndices;
 		this.methodIndices = methodIndices;
 		this.accessFlags = accessFlags;
@@ -168,7 +172,16 @@ public class RealClass {
 		}
 		return false;
 	}
-
+	
+	public boolean searchForInt(int required) {
+		for (Integer entry : intConstants) {
+			if (entry.intValue() == required) {
+				return true;
+			}
+		}
+		return false;
+	}
+	
 	public boolean searchForStringContaining(String requiredValue) {
 		for (Integer entry : stringIndices) {
 			String entryValue = getStringValueOfConstant(entry);
@@ -196,11 +209,28 @@ public class RealClass {
 			String value = getStringValueOfConstant(entry.getValue2());
 			String[] args = readArgumentsAndReturn(value);
 
+			int argsTrue = -1;
 			if(arguments.length == args.length) {
+				argsTrue = 0;
 				for(int i = 0; i < args.length; i++) {
-					if(arguments[i] != null && !arguments[i].equals(args[i]))
-						return false;
+					if(arguments[i] == null || arguments[i].equals(args[i]))
+						argsTrue++;
 				}
+			}
+			
+			if (argsTrue == args.length) {
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	public boolean hasMethodWithNoArgs() {
+		for (ReferenceIndex entry : methodIndices) {
+			String value = getStringValueOfConstant(entry.getValue2());
+			String split = value.substring(1).split("\\(")[0].split("\\)")[0];
+
+			if (split.equals("")) {
 				return true;
 			}
 		}

--- a/src/main/java/amidst/clazz/real/RealClassBuilder.java
+++ b/src/main/java/amidst/clazz/real/RealClassBuilder.java
@@ -33,6 +33,7 @@ public class RealClassBuilder {
 			List<Float> floatConstants = new ArrayList<>();
 			List<Double> doubleConstants = new ArrayList<>();
 			List<Long> longConstants = new ArrayList<>();
+			List<Integer> intConstants = new ArrayList<>();
 			List<Integer> stringIndices = new ArrayList<>();
 			List<ReferenceIndex> methodIndices = new ArrayList<>();
 			readConstants(
@@ -44,6 +45,7 @@ public class RealClassBuilder {
 					floatConstants,
 					doubleConstants,
 					longConstants,
+					intConstants,
 					stringIndices);
 			int accessFlags = readAccessFlags(stream);
 			skipThisClass(stream);
@@ -70,6 +72,7 @@ public class RealClassBuilder {
 					floatConstants,
 					doubleConstants,
 					longConstants,
+					intConstants,
 					stringIndices,
 					methodIndices,
 					accessFlags,
@@ -106,11 +109,12 @@ public class RealClassBuilder {
 			List<Float> floatConstants,
 			List<Double> doubleConstants,
 			List<Long> longConstants,
+			List<Integer> intConstants,
 			List<Integer> stringIndices) throws IOException {
 		for (int q = 0; q < cpSize; q++) {
 			byte type = stream.readByte();
 			constantTypes[q] = type;
-			constants[q] = readConstant(stream, type, utf8Constants, floatConstants, doubleConstants, longConstants, stringIndices);
+			constants[q] = readConstant(stream, type, utf8Constants, floatConstants, doubleConstants, longConstants, intConstants, stringIndices);
 			if (RealClassConstantType.isQIncreasing(type)) {
 				q++;
 			}
@@ -124,12 +128,13 @@ public class RealClassBuilder {
 			List<Float> floatConstants,
 			List<Double> doubleConstants,
 			List<Long> longConstants,
+			List<Integer> intConstants,
 			List<Integer> stringIndices) throws IOException {
 		switch (type) {
 		case RealClassConstantType.STRING:
 			return readString(stream, type, utf8Constants);
 		case RealClassConstantType.INTEGER:
-			return readInteger(stream, type);
+			return readInteger(stream, type, intConstants);
 		case RealClassConstantType.FLOAT:
 			return readFloat(stream, type, floatConstants);
 		case RealClassConstantType.LONG:
@@ -174,8 +179,9 @@ public class RealClassBuilder {
 		return new String(result);
 	}
 
-	private RealClassConstant<Integer> readInteger(DataInputStream stream, byte type) throws IOException {
+	private RealClassConstant<Integer> readInteger(DataInputStream stream, byte type, List<Integer> intConstants) throws IOException {
 		int value = stream.readInt();
+		intConstants.add(value);
 		return new RealClassConstant<>(type, value);
 	}
 

--- a/src/main/java/amidst/mojangapi/minecraftinterface/local/DefaultClassTranslator.java
+++ b/src/main/java/amidst/mojangapi/minecraftinterface/local/DefaultClassTranslator.java
@@ -1,28 +1,6 @@
 package amidst.mojangapi.minecraftinterface.local;
 
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.CLASS_BIOME;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.CLASS_BIOME_ZOOMER;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.CLASS_GAME_TYPE;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.CLASS_NOISE_BIOME_PROVIDER;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.CLASS_REGISTRY;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.CLASS_REGISTRY_KEY;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.CLASS_WORLD_DATA;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.CLASS_WORLD_SETTINGS;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.CLASS_WORLD_TYPE;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.CONSTRUCTOR_REGISTRY_KEY;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.CONSTRUCTOR_WORLD_DATA;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.CONSTRUCTOR_WORLD_SETTINGS;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.FIELD_REGISTRY_META_REGISTRY;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.FIELD_WORLD_TYPE_AMPLIFIED;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.FIELD_WORLD_TYPE_CUSTOMIZED;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.FIELD_WORLD_TYPE_DEFAULT;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.FIELD_WORLD_TYPE_FLAT;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.FIELD_WORLD_TYPE_LARGE_BIOMES;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.METHOD_BIOME_ZOOMER_GET_BIOME;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.METHOD_NOISE_BIOME_PROVIDER_GET_BIOME;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.METHOD_REGISTRY_GET_BY_KEY;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.METHOD_REGISTRY_GET_ID;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.METHOD_WORLD_DATA_MAP_SEED;
+import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.*;
 
 import amidst.clazz.real.AccessFlags;
 import amidst.clazz.translator.ClassTranslator;
@@ -40,28 +18,15 @@ public enum DefaultClassTranslator {
 	private ClassTranslator createClassTranslator() {
 	    return ClassTranslator
             .builder()
-                .ifDetect(c ->
-                        c.getNumberOfConstructors() == 3
-                        && c.getNumberOfFields() == 3
-                        && c.getField(0).hasFlags(AccessFlags.PRIVATE | AccessFlags.STATIC | AccessFlags.FINAL)
-                        && c.searchForUtf8EqualTo("argument.id.invalid")
-                        && c.searchForUtf8EqualTo("minecraft")
-                )
-                .thenDeclareOptional(CLASS_REGISTRY_KEY)
-                    .requiredConstructor(CONSTRUCTOR_REGISTRY_KEY).real("java.lang.String").end()
-            .next()
-                .ifDetect(c -> c.getNumberOfConstructors() <= 1
-                    && c.getNumberOfFields() > 15
-                    && c.searchForUtf8EqualTo("block")
-                    && c.searchForUtf8EqualTo("potion")
-                    && c.searchForUtf8EqualTo("biome")
-                    && c.searchForUtf8EqualTo("item")
-                )
-                .thenDeclareOptional(CLASS_REGISTRY)
-                    .requiredField(FIELD_REGISTRY_META_REGISTRY, "f")
-                    .requiredMethod(METHOD_REGISTRY_GET_ID, "a").real("java.lang.Object").end()
-                    .requiredMethod(METHOD_REGISTRY_GET_BY_KEY, "a").symbolic(CLASS_REGISTRY_KEY).end()
-
+		    .ifDetect(c -> c.getNumberOfConstructors() <= 1
+		        && c.getNumberOfFields() > 15
+		        && c.searchForUtf8EqualTo("block")
+		        && c.searchForUtf8EqualTo("potion")
+		        && c.searchForUtf8EqualTo("biome")
+		        && c.searchForUtf8EqualTo("item")
+		    )
+		    .thenDeclareOptional(CLASS_REGISTRY)
+		    	.requiredField(FIELD_REGISTRY_META_REGISTRY, "f")
             .next()
                 .ifDetect(c -> c.searchForStringContaining("default_1_1"))
                 .thenDeclareRequired(CLASS_WORLD_TYPE)
@@ -71,52 +36,106 @@ public enum DefaultClassTranslator {
                     .requiredField(FIELD_WORLD_TYPE_AMPLIFIED,    "e")
                     .requiredField(FIELD_WORLD_TYPE_CUSTOMIZED,   "f")
             .next()
-                .ifDetect(c -> c.getRealSuperClassName().equals("java/lang/Enum")
-                    && c.searchForUtf8EqualTo("gameMode.")
-                )
-                .thenDeclareRequired(CLASS_GAME_TYPE)
-            .next()
-                .ifDetect(c -> !c.getRealClassName().contains("$")
-                    && c.isFinal()
-                    && c.getNumberOfConstructors() == 2
-                    && c.getNumberOfFields() >= 5
-                    && c.getNumberOfFields() <= 10
-                    && c.getField(1).hasFlags(AccessFlags.PRIVATE | AccessFlags.FINAL)
-                )
-                .thenDeclareRequired(CLASS_WORLD_SETTINGS)
-                    .requiredConstructor(CONSTRUCTOR_WORLD_SETTINGS).real("long").symbolic(CLASS_GAME_TYPE).real("boolean").real("boolean").symbolic(CLASS_WORLD_TYPE).end()
-            .next()
                 .ifDetect(c -> c.getNumberOfFields() > 40
                     && c.searchForUtf8EqualTo("SizeOnDisk")
                 )
-                .thenDeclareRequired(CLASS_WORLD_DATA)
-                    .requiredConstructor(CONSTRUCTOR_WORLD_DATA).symbolic(CLASS_WORLD_SETTINGS).real("java.lang.String").end()
-                    .requiredMethod(METHOD_WORLD_DATA_MAP_SEED, "c").real("long").end()
-            .next()
-                .ifDetect(c -> c.getRealClassName().contains("$")
-                    && c.isInterface()
-                    && c.getNumberOfMethods() == 1
-                    && c.hasMethodWithRealArgsReturning("int", "int", "int", null)
-                    && !c.hasMethodWithRealArgsReturning("int", "int", "int", "boolean")
-                )
-                .thenDeclareRequired(CLASS_NOISE_BIOME_PROVIDER)
-                    .requiredMethod(METHOD_NOISE_BIOME_PROVIDER_GET_BIOME, "b").real("int").real("int").real("int").end()
-            .next()
-                .ifDetect(c -> !c.getRealClassName().contains("$")
-                    && c.getRealSuperClassName().equals("java/lang/Enum")
-                    && c.hasMethodWithRealArgsReturning("long", "int", "int", "int", null, null)
-                    && c.getNumberOfMethods() == 4
-                )
-                .thenDeclareRequired(CLASS_BIOME_ZOOMER)
-                    .requiredMethod(METHOD_BIOME_ZOOMER_GET_BIOME, "a").real("long").real("int").real("int").real("int").symbolic(CLASS_NOISE_BIOME_PROVIDER).end()
-            .next()
-                .ifDetect(c ->
-                    c.getNumberOfConstructors() == 1
-                    && c.getNumberOfFields() > 0
-                    && c.getField(0).hasFlags(AccessFlags.STATIC | AccessFlags.FINAL)
-                    && (c.searchForFloat(0.62222224F) || c.searchForUtf8EqualTo("Feature placement"))
-                )
-                .thenDeclareRequired(CLASS_BIOME)
+                .thenDeclareRequired(CLASS_LEVEL_DATA)
+                    .requiredMethod(METHOD_LEVEL_DATA_MAP_SEED, "c").real("long").end()
+			.next()
+				.ifDetect(c ->
+					c.searchForLong(1000L)
+					&& c.searchForLong(2001L)
+					&& c.searchForLong(2000L)
+				)
+				.thenDeclareRequired(CLASS_LAYERS)
+					.requiredMethod(METHOD_LAYERS_GET_DEFAULT_LAYER, "a").symbolic(CLASS_WORLD_TYPE).symbolic(CLASS_GEN_SETTINGS).real("java.util.function.LongFunction").end()
+			.next()
+				.ifDetect(c -> ( // before 18w46a
+						c.getNumberOfConstructors() == 1
+						&& c.getNumberOfFields() >= 15
+						&& c.getNumberOfMethods() >= 19
+						&& c.searchForFloat(684.412F)
+					) || ( // from 18w46a
+						!c.getRealClassName().contains("$")
+						&& !c.getRealSuperClassName().equals("java/lang/Object")
+						&& c.getNumberOfFields() >= 4
+						&& c.getNumberOfMethods() == c.getNumberOfFields()
+						&& c.getNumberOfConstructors() >= 1
+						&& c.getField(0).hasFlags(AccessFlags.FINAL | AccessFlags.PRIVATE)
+						&& !c.getField(0).hasFlags(AccessFlags.STATIC)
+                        && c.getField(2).hasFlags(AccessFlags.FINAL | AccessFlags.PRIVATE)
+						&& !c.searchForStringContaining("textures")
+					    && c.hasMethodWithNoArgs()
+					    && !c.hasMethodWithRealArgsReturning(null, null)
+					    && !c.hasMethodWithRealArgsReturning(null, null, null)
+					    && !c.hasMethodWithRealArgsReturning(null, null, null, null)
+					    && !c.hasMethodWithRealArgsReturning(null, null, null, null, null)
+					)
+				)
+				.thenDeclareRequired(CLASS_GEN_SETTINGS)
+					.requiredConstructor(CONSTRUCTOR_GEN_SETTINGS).end()
+			.next()
+				.ifDetect(c -> 
+					(c.getNumberOfMethods() == 2 || c.getNumberOfMethods() == 3)
+					&& (c.getNumberOfFields() == 3 || c.getNumberOfFields() == 4)
+					&& c.searchForInt(Integer.MIN_VALUE)
+					&& c.getRealSuperClassName().equals("java/lang/Object")
+					&& c.getNumberOfConstructors() == 1
+					&& c.getField(0).hasFlags(AccessFlags.PRIVATE | AccessFlags.FINAL)
+					&& c.getField(1).hasFlags(AccessFlags.PRIVATE | AccessFlags.FINAL)
+					&& c.getField(2).hasFlags(AccessFlags.PRIVATE | AccessFlags.FINAL)
+					&& c.hasMethodWithRealArgsReturning("int", "int", "int")
+					&& c.hasMethodWithNoArgs()
+					&& c.isFinal()
+				)
+				.thenDeclareRequired(CLASS_LAZY_AREA)
+					.requiredMethod(METHOD_LAZY_AREA_GET, "a").real("int").real("int").end()
+					.optionalField(FIELD_LAZY_AREA_PIXEL_TRANSFORMER, "a")
+			.next()
+				.ifDetect(c -> 
+				c.searchForFloat(0.25f)
+				&& c.searchForInt(Integer.MIN_VALUE)
+				&& c.getNumberOfFields() == 5
+				)
+				.thenDeclareRequired(CLASS_LAZY_AREA_CONTEXT)
+					.requiredConstructor(CONSTRUCTOR_LAZY_AREA_CONTEXT).real("int").real("long").real("long").end()
+			.next()
+				.ifDetect(c -> 
+					c.isInterface()
+					&& c.hasMethodWithNoArgs()
+					&& c.getNumberOfMethods() == 1
+					&& c.getNumberOfConstructors() == 0
+					&& c.getNumberOfFields() == 0
+					&& c.searchForUtf8EqualTo("make")
+				)
+				.thenDeclareRequired(CLASS_AREA_FACTORY)
+					.requiredMethod(METHOD_AREA_FACTORY_MAKE, "make").end()
+			.next()
+				.ifDetect(c -> 
+					c.isInterface()
+					&& c.hasMethodWithRealArgsReturning("int", "int", "int")
+					&& c.getNumberOfMethods() == 1
+					&& c.getNumberOfConstructors() == 0
+					&& c.getNumberOfFields() == 0
+					&& c.searchForUtf8EqualTo("apply")
+				)
+				.thenDeclareRequired(CLASS_PIXEL_TRANSFORMER)
+					.requiredMethod(METHOD_PIXEL_TRANSFORMER_APPLY, "apply").real("int").real("int").end()
+			.next()
+				.ifDetect(c -> 
+					//c.getRealClassName().equals("blx")
+					c.getNumberOfMethods() == 7
+					&& c.getNumberOfFields() == 2
+					&& c.getNumberOfConstructors() == 1
+					&& c.searchForDouble(4.0D)
+					&& c.searchForDouble(0.5D)
+					&& c.searchForDouble(0.9D)
+					&& c.searchForDouble(1024.0D)
+					&& c.searchForLong(1024L)
+					&& c.hasMethodWithRealArgsReturning("long", "int", "int", "int", "double", "double", "double", null)
+				)
+				.thenDeclareRequired(CLASS_FUZZY_OFFSET_BIOME_ZOOMER)
+					.requiredMethod(METHOD_FUZZY_OFFSET_BIOME_ZOOMER_GET_FIDDLE_DISTANCE, "a").real("long").real("int").real("int").real("int").real("double").real("double").real("double").end()
             .construct();
 	}
 	// @formatter:on

--- a/src/main/java/amidst/mojangapi/minecraftinterface/local/LocalMinecraftInterface.java
+++ b/src/main/java/amidst/mojangapi/minecraftinterface/local/LocalMinecraftInterface.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.function.LongFunction;
 
 import amidst.clazz.symbolic.SymbolicClass;
+import amidst.clazz.symbolic.SymbolicMethod;
 import amidst.clazz.symbolic.SymbolicObject;
 import amidst.mojangapi.minecraftinterface.MinecraftInterface;
 import amidst.mojangapi.minecraftinterface.MinecraftInterfaceException;
@@ -30,6 +31,14 @@ public class LocalMinecraftInterface implements MinecraftInterface {
      * access to the quarter-scale biome data.
      */
     private SymbolicObject pixelTransformer;
+    
+    /**
+     * A method used to retrieve the full resolution biome data.
+     * We create a SymbolicMethod for it so we dont lose performance
+     * searching the SymbolicClass for it every time it's called.
+     */
+    private SymbolicMethod getFiddleDistanceMethod;
+    
     /**
      * The seed used by the FuzzyOffsetBiomeZoomer during interpolation.
      * It is derived from the world seed.
@@ -113,6 +122,7 @@ public class LocalMinecraftInterface implements MinecraftInterface {
 	    try {
             seedForBiomeZoomer = (long) levelDataClass.callStaticMethod(SymbolicNames.METHOD_LEVEL_DATA_MAP_SEED, seed);
             pixelTransformer = createPixelTransformerObject(seed, worldType);
+            getFiddleDistanceMethod = fuzzyOffsetBiomeZoomerClass.getMethod(SymbolicNames.METHOD_FUZZY_OFFSET_BIOME_ZOOMER_GET_FIDDLE_DISTANCE);
             
         } catch(IllegalArgumentException | IllegalAccessException | InstantiationException | InvocationTargetException e) {
             throw new MinecraftInterfaceException("unable to create world", e);
@@ -200,7 +210,7 @@ public class LocalMinecraftInterface implements MinecraftInterface {
            double var27 = var21 ? var13 : var13 - 1.0D;
            double var29 = var22 ? var15 : var15 - 1.0D;
            double var31 = var23 ? var17 : var17 - 1.0D;
-           var19[var20] = (double) fuzzyOffsetBiomeZoomerClass.callStaticMethod(SymbolicNames.METHOD_FUZZY_OFFSET_BIOME_ZOOMER_GET_FIDDLE_DISTANCE, seedForBiomeZoomer, var24, var25, var26, var27, var29, var31);
+           var19[var20] = (double) getFiddleDistanceMethod.callStatic(seedForBiomeZoomer, var24, var25, var26, var27, var29, var31);
         }
 
         int var33 = 0;

--- a/src/main/java/amidst/mojangapi/minecraftinterface/local/SymbolicNames.java
+++ b/src/main/java/amidst/mojangapi/minecraftinterface/local/SymbolicNames.java
@@ -6,13 +6,8 @@ import amidst.documentation.Immutable;
 public enum SymbolicNames {
 	;
 
-    public static final String CLASS_REGISTRY = "Registry";
-    public static final String FIELD_REGISTRY_META_REGISTRY = "metaRegistry";
-    public static final String METHOD_REGISTRY_GET_BY_KEY = "getByKey";
-    public static final String METHOD_REGISTRY_GET_ID = "getId";
-
-    public static final String CLASS_REGISTRY_KEY = "RegistryKey";
-    public static final String CONSTRUCTOR_REGISTRY_KEY = "<init>";
+	public static final String CLASS_REGISTRY = "Registry";
+	public static final String FIELD_REGISTRY_META_REGISTRY = "metaRegistry";
 
 	// TODO: correctly manage world types; remove duplication with legacy SymbolicNames
 	public static final String CLASS_WORLD_TYPE = "WorldType";
@@ -22,20 +17,29 @@ public enum SymbolicNames {
 	public static final String FIELD_WORLD_TYPE_AMPLIFIED = "amplified";
 	public static final String FIELD_WORLD_TYPE_CUSTOMIZED = "customized";
 
-	public static final String CLASS_WORLD_DATA = "WorldData";
-	public static final String METHOD_WORLD_DATA_MAP_SEED = "mapSeed";
-	public static final String CONSTRUCTOR_WORLD_DATA = "<init>";
+	public static final String CLASS_LEVEL_DATA = "LevelData";
+	public static final String METHOD_LEVEL_DATA_MAP_SEED = "mapSeed";
 
-	public static final String CLASS_WORLD_SETTINGS = "WorldSettings";
-	public static final String CONSTRUCTOR_WORLD_SETTINGS = "<init>";
+	// LazyArea quarter resolution data retreival
+	public static final String CLASS_LAYERS = "Layers";
+	public static final String METHOD_LAYERS_GET_DEFAULT_LAYER = "getDefaultLayer";
 
-	public static final String CLASS_GAME_TYPE = "GameType";
+	public static final String CLASS_GEN_SETTINGS = "OverworldGenSettings";
+	public static final String CONSTRUCTOR_GEN_SETTINGS = "<init>";
 
-	public static final String CLASS_NOISE_BIOME_PROVIDER = "NoiseBiomeProvider";
-	public static final String METHOD_NOISE_BIOME_PROVIDER_GET_BIOME = "getBiome";
+	public static final String CLASS_LAZY_AREA = "LazyArea";
+	public static final String METHOD_LAZY_AREA_GET = "get";
+	public static final String FIELD_LAZY_AREA_PIXEL_TRANSFORMER = "pixelTransformer";
 
-	public static final String CLASS_BIOME_ZOOMER = "OverworldBiomeZoomer";
-	public static final String METHOD_BIOME_ZOOMER_GET_BIOME = "getBiome";
+	public static final String CLASS_LAZY_AREA_CONTEXT = "LazyAreaContext";
+	public static final String CONSTRUCTOR_LAZY_AREA_CONTEXT = "<init>";
 
-    public static final String CLASS_BIOME = "Biome";
+	public static final String CLASS_AREA_FACTORY = "AreaFactory";
+	public static final String METHOD_AREA_FACTORY_MAKE = "make";
+
+	public static final String CLASS_PIXEL_TRANSFORMER = "PixelTransformer";
+	public static final String METHOD_PIXEL_TRANSFORMER_APPLY = "apply";
+
+	public static final String CLASS_FUZZY_OFFSET_BIOME_ZOOMER = "FuzzyOffsetBiomeZoomer";
+	public static final String METHOD_FUZZY_OFFSET_BIOME_ZOOMER_GET_FIDDLE_DISTANCE = "getFiddledDistance";
 }


### PR DESCRIPTION
Instead of using BiomeZoomer, we can use LazyArea and then zoom it ourselves. This allows us to use previous performance improvements that were used with LazyArea. I also changed some RealClass stuff to detect classes more reliably and easily.