### PR TITLE
After loading registry, stop datafixer threads

### DIFF
--- a/src/main/java/amidst/mojangapi/minecraftinterface/local/DefaultClassTranslator.java
+++ b/src/main/java/amidst/mojangapi/minecraftinterface/local/DefaultClassTranslator.java
@@ -97,7 +97,8 @@ public enum DefaultClassTranslator {
                 .thenDeclareRequired(CLASS_BIOME)
             .next()
 				.ifDetect(c -> 
-					c.searchForStringContaining("Server-Worker-")
+					(c.searchForStringContaining("Server-Worker-")
+					| c.searchForStringContaining("Worker-"))
 					&& c.searchForStringContaining("os.name")
 					&& c.searchForLong(1000000L)
 				)

--- a/src/main/java/amidst/mojangapi/minecraftinterface/local/DefaultClassTranslator.java
+++ b/src/main/java/amidst/mojangapi/minecraftinterface/local/DefaultClassTranslator.java
@@ -1,28 +1,6 @@
 package amidst.mojangapi.minecraftinterface.local;
 
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.CLASS_BIOME;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.CLASS_BIOME_ZOOMER;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.CLASS_GAME_TYPE;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.CLASS_NOISE_BIOME_PROVIDER;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.CLASS_REGISTRY;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.CLASS_REGISTRY_KEY;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.CLASS_WORLD_DATA;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.CLASS_WORLD_SETTINGS;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.CLASS_WORLD_TYPE;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.CONSTRUCTOR_REGISTRY_KEY;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.CONSTRUCTOR_WORLD_DATA;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.CONSTRUCTOR_WORLD_SETTINGS;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.FIELD_REGISTRY_META_REGISTRY;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.FIELD_WORLD_TYPE_AMPLIFIED;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.FIELD_WORLD_TYPE_CUSTOMIZED;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.FIELD_WORLD_TYPE_DEFAULT;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.FIELD_WORLD_TYPE_FLAT;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.FIELD_WORLD_TYPE_LARGE_BIOMES;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.METHOD_BIOME_ZOOMER_GET_BIOME;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.METHOD_NOISE_BIOME_PROVIDER_GET_BIOME;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.METHOD_REGISTRY_GET_BY_KEY;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.METHOD_REGISTRY_GET_ID;
-import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.METHOD_WORLD_DATA_MAP_SEED;
+import static amidst.mojangapi.minecraftinterface.local.SymbolicNames.*;
 
 import amidst.clazz.real.AccessFlags;
 import amidst.clazz.translator.ClassTranslator;
@@ -117,6 +95,14 @@ public enum DefaultClassTranslator {
                     && (c.searchForFloat(0.62222224F) || c.searchForUtf8EqualTo("Feature placement"))
                 )
                 .thenDeclareRequired(CLASS_BIOME)
+            .next()
+				.ifDetect(c -> 
+					c.searchForStringContaining("Server-Worker-")
+					&& c.searchForStringContaining("os.name")
+					&& c.searchForLong(1000000L)
+				)
+				.thenDeclareOptional(CLASS_UTIL)
+					.optionalField(FIELD_UTIL_SERVER_EXECUTOR, "c")
             .construct();
 	}
 	// @formatter:on

--- a/src/main/java/amidst/mojangapi/minecraftinterface/local/LocalMinecraftInterface.java
+++ b/src/main/java/amidst/mojangapi/minecraftinterface/local/LocalMinecraftInterface.java
@@ -6,6 +6,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ExecutorService;
 
 import amidst.clazz.symbolic.SymbolicClass;
 import amidst.clazz.symbolic.SymbolicObject;
@@ -28,6 +29,7 @@ public class LocalMinecraftInterface implements MinecraftInterface {
 	private final SymbolicClass worldDataClass;
 	private final SymbolicClass noiseBiomeProviderClass;
 	private final SymbolicClass overworldBiomeZoomerClass;
+	private final SymbolicClass utilClass;
 
 	private MethodHandle registryGetIdMethod;
     private MethodHandle biomeProviderGetBiomeMethod;
@@ -68,6 +70,7 @@ public class LocalMinecraftInterface implements MinecraftInterface {
         this.worldDataClass = symbolicClassMap.get(SymbolicNames.CLASS_WORLD_DATA);
         this.noiseBiomeProviderClass = symbolicClassMap.get(SymbolicNames.CLASS_NOISE_BIOME_PROVIDER);
         this.overworldBiomeZoomerClass = symbolicClassMap.get(SymbolicNames.CLASS_BIOME_ZOOMER);
+        this.utilClass = symbolicClassMap.get(SymbolicNames.CLASS_UTIL);
 	}
 
 	@Override
@@ -196,6 +199,11 @@ public class LocalMinecraftInterface implements MinecraftInterface {
 	                .getStaticFieldValue(SymbolicNames.FIELD_REGISTRY_META_REGISTRY)).getObject();
             biomeRegistry = Objects.requireNonNull(getFromRegistryByKey(metaRegistry, "biome"));
             biomeProviderRegistry = Objects.requireNonNull(getFromRegistryByKey(metaRegistry, "biome_source_type"));
+			try {
+				((ExecutorService) utilClass.getStaticFieldValue(SymbolicNames.FIELD_UTIL_SERVER_EXECUTOR)).shutdownNow();
+			} catch (NullPointerException e) {
+				AmidstLogger.warn("Unable to shut down Server-Worker threads");
+			}
 
             registryGetIdMethod = getMethodHandle(registryClass, SymbolicNames.METHOD_REGISTRY_GET_ID);
             biomeProviderGetBiomeMethod = getMethodHandle(noiseBiomeProviderClass, SymbolicNames.METHOD_NOISE_BIOME_PROVIDER_GET_BIOME);

--- a/src/main/java/amidst/mojangapi/minecraftinterface/local/LocalMinecraftInterface.java
+++ b/src/main/java/amidst/mojangapi/minecraftinterface/local/LocalMinecraftInterface.java
@@ -197,13 +197,14 @@ public class LocalMinecraftInterface implements MinecraftInterface {
 	    try {
 	        Object metaRegistry = ((SymbolicObject) registryClass
 	                .getStaticFieldValue(SymbolicNames.FIELD_REGISTRY_META_REGISTRY)).getObject();
-            biomeRegistry = Objects.requireNonNull(getFromRegistryByKey(metaRegistry, "biome"));
-            biomeProviderRegistry = Objects.requireNonNull(getFromRegistryByKey(metaRegistry, "biome_source_type"));
 			try {
 				((ExecutorService) utilClass.getStaticFieldValue(SymbolicNames.FIELD_UTIL_SERVER_EXECUTOR)).shutdownNow();
 			} catch (NullPointerException e) {
 				AmidstLogger.warn("Unable to shut down Server-Worker threads");
 			}
+			
+            biomeRegistry = Objects.requireNonNull(getFromRegistryByKey(metaRegistry, "biome"));
+            biomeProviderRegistry = Objects.requireNonNull(getFromRegistryByKey(metaRegistry, "biome_source_type"));
 
             registryGetIdMethod = getMethodHandle(registryClass, SymbolicNames.METHOD_REGISTRY_GET_ID);
             biomeProviderGetBiomeMethod = getMethodHandle(noiseBiomeProviderClass, SymbolicNames.METHOD_NOISE_BIOME_PROVIDER_GET_BIOME);

--- a/src/main/java/amidst/mojangapi/minecraftinterface/local/SymbolicNames.java
+++ b/src/main/java/amidst/mojangapi/minecraftinterface/local/SymbolicNames.java
@@ -13,6 +13,9 @@ public enum SymbolicNames {
 
     public static final String CLASS_REGISTRY_KEY = "RegistryKey";
     public static final String CONSTRUCTOR_REGISTRY_KEY = "<init>";
+    
+	public static final String CLASS_UTIL = "Util";
+	public static final String FIELD_UTIL_SERVER_EXECUTOR = "SERVER_EXECUTOR";
 
 	// TODO: correctly manage world types; remove duplication with legacy SymbolicNames
 	public static final String CLASS_WORLD_TYPE = "WorldType";


### PR DESCRIPTION
The threads that register all of the datafixers take up a TON of CPU usage for a few minutes after loading the Registry class, and it doesn't help us in any way. We can just stop them a bit after they are created by getting the ExecutorService running them. I couldn't find a way to load the class without the threads being created, so I just did this instead.

Also instead of manually importing every field in the SymbolicNames, I just imported all of them. I feel like there may have been a reason for this, so feel free to change it back.

**EDIT**: The reason I don't use the method for this built into `Util` is because it requests a shutdown to the threads, waits a few seconds for them to shutdown, and then if it isn't already shut down, forcefully shuts the threads down. In my testing, the threads always had to be forcefully shut down. The way I implemented it skips the few seconds added to loading time.