### PR TITLE
Some zoom improvements

### DIFF
--- a/src/main/java/amidst/gui/main/Actions.java
+++ b/src/main/java/amidst/gui/main/Actions.java
@@ -168,12 +168,12 @@ public class Actions {
 
 	@CalledOnlyBy(AmidstThread.EDT)
 	public void zoomIn() {
-		adjustZoom(-1);
+		adjustZoom(-4);
 	}
 
 	@CalledOnlyBy(AmidstThread.EDT)
 	public void zoomOut() {
-		adjustZoom(1);
+		adjustZoom(4);
 	}
 
 	@CalledOnlyBy(AmidstThread.EDT)

--- a/src/main/java/amidst/gui/main/viewer/Zoom.java
+++ b/src/main/java/amidst/gui/main/viewer/Zoom.java
@@ -11,8 +11,8 @@ import amidst.settings.Setting;
 public class Zoom {
 	private int remainingTicks = 0;
 	private int level = 0;
-	private double target = 0.25f;
-	private double current = 0.25f;
+	private double target = zoomFromLevel(0);
+	private double current = zoomFromLevel(0);
 
 	private Point mousePosition = new Point();
 
@@ -21,6 +21,10 @@ public class Zoom {
 	@CalledOnlyBy(AmidstThread.EDT)
 	public Zoom(Setting<Boolean> maxZoomSetting) {
 		this.maxZoomSetting = maxZoomSetting;
+	}
+
+	private static float zoomFromLevel(int level) {
+		return (float) (0.25 * Math.pow(2, -level / 8.0));
 	}
 
 	@CalledOnlyBy(AmidstThread.EDT)
@@ -44,24 +48,24 @@ public class Zoom {
 		this.mousePosition = mousePosition;
 		if (notches > 0) {
 			if (level < getMaxZoomLevel()) {
-				target /= 1.1;
 				level++;
 				remainingTicks = 100;
 			}
-		} else if (level > -20) {
-			target *= 1.1;
+		} else if (level > getMinZoomLevel()) {
 			level--;
 			remainingTicks = 100;
 		}
+		target = zoomFromLevel(level);
 	}
 
 	@CalledOnlyBy(AmidstThread.EDT)
 	private int getMaxZoomLevel() {
-		if (maxZoomSetting.get()) {
-			return 10;
-		} else {
-			return 10000;
-		}
+		return maxZoomSetting.get() ? 12 : 10000;
+	}
+
+	@CalledOnlyBy(AmidstThread.EDT)
+	private int getMinZoomLevel() {
+		return -20;
 	}
 
 	@CalledOnlyBy(AmidstThread.EDT)

--- a/src/main/java/amidst/gui/main/viewer/Zoom.java
+++ b/src/main/java/amidst/gui/main/viewer/Zoom.java
@@ -45,17 +45,24 @@ public class Zoom {
 
 	@CalledOnlyBy(AmidstThread.EDT)
 	public void adjustZoom(Point mousePosition, int notches) {
-		this.mousePosition = mousePosition;
+		int oldLevel = level;
+		int maxLevel = getMaxZoomLevel();
+		int minLevel = getMinZoomLevel();
+
 		if (notches > 0) {
-			if (level < getMaxZoomLevel()) {
-				level++;
-				remainingTicks = 100;
+			if (level < maxLevel) {
+				level = Math.min(level + notches, maxLevel);
 			}
-		} else if (level > getMinZoomLevel()) {
-			level--;
-			remainingTicks = 100;
+		} else if (notches < 0) {
+			if (level > minLevel) {
+				level = Math.max(level + notches, minLevel);
+			}
 		}
-		target = zoomFromLevel(level);
+		if (oldLevel != level) {
+			this.mousePosition = mousePosition;
+			target = zoomFromLevel(level);
+			remainingTicks = 100 * Math.abs(oldLevel - level);
+		}
 	}
 
 	@CalledOnlyBy(AmidstThread.EDT)

--- a/src/main/java/amidst/gui/main/viewer/widget/OffsetWidget.java
+++ b/src/main/java/amidst/gui/main/viewer/widget/OffsetWidget.java
@@ -5,19 +5,21 @@ import amidst.documentation.CalledOnlyBy;
 
 public abstract class OffsetWidget extends Widget {
 	private int xOffset, yOffset;
-	
+
 	protected OffsetWidget(CornerAnchorPoint anchor, int xOffset, int yOffset) {
 		super(anchor);
 		this.xOffset = xOffset;
 		this.yOffset = yOffset;
 	}
-	
+
 	@CalledOnlyBy(AmidstThread.EDT)
+	@Override
 	protected void setX(int x) {
 		super.setX(x + xOffset);
 	}
 
 	@CalledOnlyBy(AmidstThread.EDT)
+	@Override
 	protected void setY(int y) {
 		super.setY(y + yOffset);
 	}


### PR DESCRIPTION
Following #722, this PR implements some changes to the zoom functionality:
- Each zoom level now corresponds to a `pow(2, 1/8) ~= 1.09` increase in the zoom scale, instead of  a `1.1` increase. This allow to hit exact powers of two every 8 levels.
- The keyboard zoom controls now increase or decrease the zoom by 4 levels (a `sqrt(2)` factor).