### PR TITLE
Add support for multiple worlds on a single MinecraftInterface

### DIFF
--- a/src/main/java/amidst/gui/export/BiomeExporterDialog.java
+++ b/src/main/java/amidst/gui/export/BiomeExporterDialog.java
@@ -1,5 +1,14 @@
 package amidst.gui.export;
 
+import static java.awt.GridBagConstraints.BOTH;
+import static java.awt.GridBagConstraints.CENTER;
+import static java.awt.GridBagConstraints.EAST;
+import static java.awt.GridBagConstraints.HORIZONTAL;
+import static java.awt.GridBagConstraints.NONE;
+import static java.awt.GridBagConstraints.SOUTH;
+import static java.awt.GridBagConstraints.SOUTHEAST;
+import static java.awt.GridBagConstraints.SOUTHWEST;
+
 import java.awt.AlphaComposite;
 import java.awt.Color;
 import java.awt.Component;
@@ -24,6 +33,7 @@ import java.text.ParseException;
 import java.util.Collections;
 import java.util.Map.Entry;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -54,19 +64,17 @@ import amidst.logging.AmidstMessageBox;
 import amidst.mojangapi.minecraftinterface.MinecraftInterfaceException;
 import amidst.mojangapi.world.World;
 import amidst.mojangapi.world.WorldOptions;
+import amidst.mojangapi.world.biome.Biome;
 import amidst.mojangapi.world.biome.UnknownBiomeIdException;
 import amidst.mojangapi.world.coordinates.CoordinatesInWorld;
 import amidst.mojangapi.world.oracle.BiomeDataOracle;
 import amidst.settings.biomeprofile.BiomeProfileSelection;
-import java.util.concurrent.Executors;
-
-import static java.awt.GridBagConstraints.*;
 
 @NotThreadSafe
 public class BiomeExporterDialog {
 	private static final int PREVIEW_SIZE = 100;
 	private static final ExecutorService previewUpdater = Executors.newSingleThreadExecutor(r -> new Thread(r, "BiomePreviewUpdater"));
-	
+
 	private final BiomeExporter biomeExporter;
 	private final Frame parentFrame;
 	private final Supplier<AmidstMenu> menuBarSupplier;
@@ -82,11 +90,11 @@ public class BiomeExporterDialog {
 	private final ImageIcon previewIcon;
 	private final JLabel previewLabel;
 	private final JDialog dialog;
-	
+
 	private WorldOptions worldOptions;
 	private BiomeDataOracle biomeDataOracle;
 	private Consumer<Entry<ProgressEntryType, Integer>> progressListener;
-	
+
 	public BiomeExporterDialog(BiomeExporter biomeExporter, Frame parentFrame, BiomeProfileSelection biomeProfileSelection, Supplier<AmidstMenu> menuBarSupplier) {
 		// @formatter:off
 		this.biomeExporter         = biomeExporter;
@@ -95,7 +103,7 @@ public class BiomeExporterDialog {
 		this.biomeProfileSelection = biomeProfileSelection;
 		this.constraints           = new GridBagConstraints();
 		this.labelPaneConstraints  = new GridBagConstraints();
-		
+
 		this.leftSpinner           = createCoordinateSpinner();
 		this.topSpinner            = createCoordinateSpinner();
 		this.rightSpinner          = createCoordinateSpinner();
@@ -105,12 +113,12 @@ public class BiomeExporterDialog {
 		this.browseButton          = createBrowseButton();
 		this.exportButton          = createExportButton();
 		this.previewImage          = new BufferedImage(PREVIEW_SIZE, PREVIEW_SIZE, BufferedImage.TYPE_INT_ARGB);
-		this.previewIcon           = new ImageIcon(new BufferedImage((int) (PREVIEW_SIZE * 2), (int) (PREVIEW_SIZE * 2), BufferedImage.TYPE_INT_ARGB));
+		this.previewIcon           = new ImageIcon(new BufferedImage(PREVIEW_SIZE * 2, PREVIEW_SIZE * 2, BufferedImage.TYPE_INT_ARGB));
 		this.previewLabel          = createPreviewLabel();
 		this.dialog                = createDialog();
 		// @formatter:on
 	}
-	
+
 	private JCheckBox createFullResCheckbox() {
 		JCheckBox newCheckBox = new JCheckBox("Full Resolution");
 		newCheckBox.addChangeListener(e -> {
@@ -118,14 +126,14 @@ public class BiomeExporterDialog {
 		});
 		return newCheckBox;
 	}
-	
+
 	private JTextField createPathField() {
 		JTextField newTextField = new JTextField();
 		newTextField.setPreferredSize(new JTextField(String.join("", Collections.nCopies(50, "_"))).getPreferredSize());
 		newTextField.setText("");
 		return newTextField;
 	}
-	
+
 	private JSpinner createCoordinateSpinner() {
 		JSpinner newSpinner = new JSpinner(new SpinnerNumberModel(0, -30000000, 30000000, 25));
 		newSpinner.addChangeListener(e -> {
@@ -133,15 +141,15 @@ public class BiomeExporterDialog {
 		});
 		return newSpinner;
 	}
-	
+
 	private JLabel createPreviewLabel() {
 		JLabel newLabel = new JLabel();
-		
+
 		newLabel.setIcon(previewIcon);
 		newLabel.setBorder(new LineBorder(Color.BLACK, 2));
 		return newLabel;
 	}
-	
+
 	private JButton createExportButton() {
 		JButton exportButton = new JButton("Export");
 		exportButton.addActionListener((e) -> {
@@ -153,7 +161,7 @@ public class BiomeExporterDialog {
 			} catch (ParseException e1) {
 				// resets itself to previous value
 			}
-			
+
 			CoordinatesInWorld topLeft = getTopLeftCoordinates();
 			CoordinatesInWorld bottomRight = getBottomRightCoordinates();
 			if (verifyImageCoordinates(topLeft, bottomRight) && verifyPathString(pathField.getText())) {
@@ -174,7 +182,7 @@ public class BiomeExporterDialog {
 		});
 		return exportButton;
 	}
-	
+
 	private boolean verifyPathString(String path) {
 		try {
 			Path p = Paths.get(path);
@@ -204,9 +212,9 @@ public class BiomeExporterDialog {
 		}
 		return false;
 	}
-	
+
 	public boolean verifyImageCoordinates(CoordinatesInWorld topLeft, CoordinatesInWorld bottomRight) {
-		if((topLeft != null && bottomRight != null) && 
+		if((topLeft != null && bottomRight != null) &&
 		   (topLeft.getX() >= bottomRight.getX() || topLeft.getY() >= bottomRight.getY())) {
 			String message = "Unable to create image: Invalid image coordinates detected.";
 			AmidstLogger.warn(message);
@@ -217,7 +225,7 @@ public class BiomeExporterDialog {
 		}
 	}
 
-	
+
 	private JButton createBrowseButton() {
 		JButton newButton = new JButton("Browse...");
 		newButton.addActionListener(e -> {
@@ -231,7 +239,7 @@ public class BiomeExporterDialog {
 
 	private Path getExportPath() {
 		Path file = null;
-		
+
 		JFileChooser fileChooser = new JFileChooser();
 		fileChooser.setFileFilter(new PNGFileFilter());
 		fileChooser.setAcceptAllFileFilterUsed(false);
@@ -239,7 +247,7 @@ public class BiomeExporterDialog {
 		if (fileChooser.showDialog(dialog, "Confirm") == JFileChooser.APPROVE_OPTION) {
 			file = Actions.appendFileExtensionIfNecessary(fileChooser.getSelectedFile().toPath(), "png");
 		}
-		
+
 		return file;
 	}
 
@@ -249,65 +257,66 @@ public class BiomeExporterDialog {
 
 	private JPanel createLabeledPanel(String label, Component component, int fillConst) {
 		JPanel newPanel = new JPanel(new GridBagLayout());
-		
+
 		JLabel newLabel = new JLabel(label);
 		newLabel.setHorizontalAlignment(SwingConstants.CENTER);
 		newLabel.setVerticalAlignment(SwingConstants.BOTTOM);
 		setLabelPaneConstraints(0, 0, 0, 0, HORIZONTAL, 0, 0, 1, 1, 1.0, 0.0, SOUTH);
 		newPanel.add(newLabel, labelPaneConstraints);
-		
+
 		setLabelPaneConstraints(0, 0, 0, 0, fillConst, 0, 1, 1, 1, 1.0, 0.0, CENTER);
 		newPanel.add(component, labelPaneConstraints);
-		
+
 		return newPanel;
 	}
-	
+
 	private JDialog createDialog() {
 		JPanel panel = new JPanel(new GridBagLayout());
-		
+
 		setConstraints(40, 0, 0, 0, NONE, 1, 1, 1, 1, 0.0, 0.0, SOUTH);
 		panel.add(createLabeledPanel("Top:", topSpinner, NONE), constraints);
-		
+
 		setConstraints(20, 20, 0, 0, NONE, 0, 2, 1, 1, 0.0, 0.0, SOUTH);
 		panel.add(createLabeledPanel("Left:", leftSpinner, NONE), constraints);
-		
+
 		setConstraints(20, 0, 0, 0, NONE, 1, 3, 1, 1, 0.0, 0.0, SOUTH);
 		panel.add(createLabeledPanel("Bottom:", bottomSpinner, NONE), constraints);
-		
+
 		setConstraints(20, 0, 0, 0, NONE, 2, 2, 1, 1, 0.0, 0.0, SOUTH);
 		panel.add(createLabeledPanel("Right:", rightSpinner, NONE), constraints);
-		
+
 		setConstraints(10, 20, 0, 0, NONE, 0, 5, 2, 1, 0.0, 0.0, SOUTHWEST);
 		panel.add(fullResCheckBox, constraints);
-		
+
 		setConstraints(0, 15, 0, 15, BOTH, 3, 0, 1, 6, 1.0, 0.0, CENTER);
 		panel.add(Box.createGlue(), constraints);
-		
+
 		setConstraints(0, 0, 0, 0, BOTH, 0, 4, 4, 1, 0.0, 1.0, CENTER);
 		panel.add(Box.createGlue(), constraints);
-		
+
 		JPanel pathPanel = new JPanel(new GridBagLayout());
-		
+
 		setConstraints(0, 0, 0, 0, HORIZONTAL, 0, 0, 1, 1, 0.0, 0.0, SOUTH);
 		pathPanel.add(createLabeledPanel("Path:", pathField, HORIZONTAL), constraints);
-		
+
 		setConstraints(0, 10, 0, 0, HORIZONTAL, 1, 0, 1, 1, 0.0, 0.0, SOUTH);
 		pathPanel.add(browseButton, constraints);
-		
+
 		setConstraints(10, 20, 20, 10, BOTH, 0, 6, 4, 2, 0.0, 0.0, SOUTHWEST);
 		panel.add(pathPanel, constraints);
-		
+
 		setConstraints(15, 10, 10, 20, BOTH, 4, 0, 1, 7, 0.0, 0.0, EAST);
 		panel.add(createLabeledPanel("Preview:", previewLabel, NONE), constraints);
-		
+
 		setConstraints(10, 10, 20, 20, NONE, 4, 7, 1, 1, 0.0, 0.0, SOUTHEAST);
 		panel.add(exportButton, constraints);
-		
+
 		JDialog newDialog = new JDialog(parentFrame, "Export Biome Image");
 		newDialog.setDefaultCloseOperation(JDialog.DO_NOTHING_ON_CLOSE);
 		newDialog.addWindowListener(new WindowAdapter() {
+			@Override
 			public void windowClosing(WindowEvent e) {
-				/* 
+				/*
 				 * This executes only when it's closed with the x button, alt f4, etc.
 				 * When this happens we know that the user did not press the ok button
 				 * to continue, so we re enable the export biomes menu button.
@@ -321,35 +330,35 @@ public class BiomeExporterDialog {
 		newDialog.setResizable(false);
 		return newDialog;
 	}
-	
+
 	private Future<?> renderTask;
-	
+
 	private void renderPreview() {
 		if(renderTask != null && !renderTask.isDone()) {
 			renderTask.cancel(true);
 		}
-		
+
 		renderTask = previewUpdater.submit(() -> {
 			final int quarterResFactor = fullResCheckBox.isSelected() ? 1 : 4;
 			try {
 				clearImage(previewImage);
-				
+
 				// We use a direct int array because it's much faster than calling setRGB()
 				int[] pixels = ((DataBufferInt) previewImage.getRaster().getDataBuffer()).getData();
-				
+
 				CoordinatesInWorld topLeft = getTopLeftCoordinates();
 				CoordinatesInWorld bottomRight = getBottomRightCoordinates();
-				
+
 				int worldWidth = (int) (bottomRight.getX() - topLeft.getX());
 				int worldHeight = (int) -(topLeft.getY() - bottomRight.getY());
-				
+
 				int worldLongestSide = Math.max(worldWidth, worldHeight);
-				
+
 				double imgToWorldFactor = worldLongestSide / (double) PREVIEW_SIZE;
-				
+
 				int imgXOffset = (int) (((worldLongestSide - worldWidth) / 2) / imgToWorldFactor);
 				int imgYOffset = (int) (((worldLongestSide - worldHeight) / 2) / imgToWorldFactor);
-				
+
 				int imgHeightWithoutBorders = previewImage.getHeight() - imgYOffset * 2;
 				int imgWidthWithoutBorders = previewImage.getWidth() - imgXOffset * 2;
 				for(int y = 0; y < imgHeightWithoutBorders; y++) {
@@ -358,22 +367,23 @@ public class BiomeExporterDialog {
 						int worldY = (int) ((y * imgToWorldFactor + topLeft.getY()) / quarterResFactor);
 						int imgX = x + imgXOffset;
 						int imgY = y + imgYOffset;
-						
+
 						// we use imgY instead of (previewImage.getHeight() - imgY - 1) to mirror the y axis
 						int imgidx = imgY * previewImage.getWidth() + imgX;
-						pixels[imgidx] = biomeProfileSelection.getBiomeColorOrUnknown(biomeDataOracle.getBiomeAt(worldX, worldY, !fullResCheckBox.isSelected())).getRGB();
+						Biome biome = biomeDataOracle.getBiomeAt(worldX, worldY, !fullResCheckBox.isSelected());
+						pixels[imgidx] = biomeProfileSelection.getBiomeColorOrUnknown(biome.getId()).getRGB();
 					}
 				}
-				
+
 				previewIcon.setImage(previewImage.getScaledInstance(previewIcon.getIconWidth(), previewIcon.getIconHeight(), Image.SCALE_FAST));
-				
+
 				SwingUtilities.invokeLater(() -> previewLabel.repaint());
 			} catch(MinecraftInterfaceException | UnknownBiomeIdException e) {
 				AmidstLogger.error(e);
 			}
 		});
 	}
-	
+
 	private void clearImage(BufferedImage img) {
 		Graphics2D graphics = (Graphics2D) img.getGraphics();
 		Composite tempComposite = graphics.getComposite();
@@ -381,20 +391,20 @@ public class BiomeExporterDialog {
 		graphics.fillRect(0, 0, img.getWidth(), img.getHeight());
 		graphics.setComposite(tempComposite);
 	}
-	
+
 	public void createAndShow(World world, FragmentGraphToScreenTranslator translator,
 			Consumer<Entry<ProgressEntryType, Integer>> progressListener) {
-		
+
 		menuBarSupplier.get().setMenuItemsEnabled(new String[] { "Export Biomes to Image ...", "Biome Profile" }, false);
-		
+
 		this.worldOptions = world.getWorldOptions();
 		this.biomeDataOracle = world.getBiomeDataOracle();
 		this.progressListener = progressListener;
-		
+
 		CoordinatesInWorld defaultTopLeft = translator.screenToWorld(new Point(0, 0));
 		CoordinatesInWorld defaultBottomRight = translator
 				.screenToWorld(new Point((int) translator.getWidth(), (int) translator.getHeight()));
-		
+
 		leftSpinner.setValue(defaultTopLeft.getX());
 		topSpinner.setValue(defaultTopLeft.getY());
 		rightSpinner.setValue(defaultBottomRight.getX());
@@ -406,24 +416,24 @@ public class BiomeExporterDialog {
 			previousPath = "";
 		}
 		pathField.setText(Paths.get(previousPath, getSuggestedFilename()).toAbsolutePath().toString());
-		
+
 		renderPreview();
 		dialog.setVisible(true);
 	}
-	
+
 	public void dispose() {
 		menuBarSupplier.get().setMenuItemsEnabled(new String[] { "Export Biomes to Image ...", "Biome Profile" }, true);
 		dialog.dispose();
 	}
-	
+
 	private CoordinatesInWorld getTopLeftCoordinates() {
 		return new CoordinatesInWorld(((Number) leftSpinner.getValue()).longValue(), ((Number) topSpinner.getValue()).longValue());
 	}
-	
+
 	private CoordinatesInWorld getBottomRightCoordinates() {
 		return new CoordinatesInWorld(((Number) rightSpinner.getValue()).longValue(), ((Number) bottomSpinner.getValue()).longValue());
 	}
-	
+
 	private void setConstraints(int iTop, int iLeft, int iBottom, int iRight, int fillConst, int gridx,
 			int gridy, int gridw, int gridh, double weightx, double weighty, int anchor) {
 		constraints.insets = new Insets(iTop, iLeft, iBottom, iRight);
@@ -436,7 +446,7 @@ public class BiomeExporterDialog {
 		constraints.weighty = weighty;
 		constraints.anchor = anchor;
 	}
-	
+
 	private void setLabelPaneConstraints(int iTop, int iLeft, int iBottom, int iRight, int fillConst, int gridx,
 			int gridy, int gridw, int gridh, double weightx, double weighty, int anchor) {
 		labelPaneConstraints.insets = new Insets(iTop, iLeft, iBottom, iRight);
@@ -449,5 +459,5 @@ public class BiomeExporterDialog {
 		labelPaneConstraints.weighty = weighty;
 		labelPaneConstraints.anchor = anchor;
 	}
-	
+
 }

--- a/src/main/java/amidst/gui/main/WorldSwitcher.java
+++ b/src/main/java/amidst/gui/main/WorldSwitcher.java
@@ -99,7 +99,6 @@ public class WorldSwitcher {
 		if (decideWorldPlayerType(world.getMovablePlayerList())) {
 			setViewerFacade(viewerFacadeFactory.create(world));
 		} else {
-			world.dispose();
 			frame.revalidate();
 			frame.repaint();
 		}

--- a/src/main/java/amidst/gui/main/viewer/ViewerFacade.java
+++ b/src/main/java/amidst/gui/main/viewer/ViewerFacade.java
@@ -101,7 +101,6 @@ public class ViewerFacade {
 		graph.dispose();
 		zoom.skipFading();
 		zoom.reset();
-		world.dispose();
 	}
 
 	@CalledOnlyBy(AmidstThread.EDT)

--- a/src/main/java/amidst/gui/seedsearcher/SeedSearcher.java
+++ b/src/main/java/amidst/gui/seedsearcher/SeedSearcher.java
@@ -98,10 +98,8 @@ public class SeedSearcher {
 			World world = runningLauncherProfile.createWorld(worldOptions);
 			if (configuration.getWorldFilter().isValid(world)) {
 				reporter.report(worldOptions);
-				world.dispose();
 				break;
 			}
-			world.dispose();
 		}
 	}
 }

--- a/src/main/java/amidst/mojangapi/RunningLauncherProfile.java
+++ b/src/main/java/amidst/mojangapi/RunningLauncherProfile.java
@@ -29,7 +29,6 @@ public class RunningLauncherProfile {
 	private final WorldBuilder worldBuilder;
 	private final LauncherProfile launcherProfile;
 	private final MinecraftInterface minecraftInterface;
-	private volatile World currentWorld = null;
 	private final Optional<WorldOptions> initialWorldOptions;
 
 	public RunningLauncherProfile(
@@ -71,15 +70,8 @@ public class RunningLauncherProfile {
 	 * created world objects.
 	 */
 	public synchronized World createWorld(WorldOptions worldOptions)
-			throws IllegalStateException,
-			MinecraftInterfaceException {
-		if (currentWorld == null) {
-			currentWorld = worldBuilder.from(minecraftInterface, this::unlock, worldOptions);
-			return currentWorld;
-		} else {
-			throw new IllegalStateException(
-					"Each minecraft interface can only handle one world at a time. Dispose the previous world before creating a new one.");
-		}
+			throws MinecraftInterfaceException {
+		return worldBuilder.from(minecraftInterface, worldOptions);
 	}
 
 	/**
@@ -88,23 +80,7 @@ public class RunningLauncherProfile {
 	 * created world objects.
 	 */
 	public synchronized World createWorldFromSaveGame(SaveGame saveGame)
-			throws IllegalStateException,
-			IOException,
-			MinecraftInterfaceException {
-		if (currentWorld == null) {
-			currentWorld = worldBuilder.fromSaveGame(minecraftInterface, this::unlock, saveGame);
-			return currentWorld;
-		} else {
-			throw new IllegalStateException(
-					"Each minecraft interface can only handle one world at a time. Dispose the previous world before creating a new one.");
-		}
-	}
-
-	private synchronized void unlock(World world) throws IllegalStateException {
-		if (currentWorld == world) {
-			currentWorld = null;
-		} else {
-			throw new IllegalStateException("The requested world is no longer the currentWorld.");
-		}
+			throws IOException, MinecraftInterfaceException {
+		return worldBuilder.fromSaveGame(minecraftInterface, saveGame);
 	}
 }

--- a/src/main/java/amidst/mojangapi/RunningLauncherProfile.java
+++ b/src/main/java/amidst/mojangapi/RunningLauncherProfile.java
@@ -64,21 +64,11 @@ public class RunningLauncherProfile {
 		}
 	}
 
-	/**
-	 * Due to the limitation of the minecraft interface, you can only work with
-	 * one world at a time. Creating a new world will break all previously
-	 * created world objects.
-	 */
 	public synchronized World createWorld(WorldOptions worldOptions)
 			throws MinecraftInterfaceException {
 		return worldBuilder.from(minecraftInterface, worldOptions);
 	}
 
-	/**
-	 * Due to the limitation of the minecraft interface, you can only work with
-	 * one world at a time. Creating a new world will break all previously
-	 * created world objects.
-	 */
 	public synchronized World createWorldFromSaveGame(SaveGame saveGame)
 			throws IOException, MinecraftInterfaceException {
 		return worldBuilder.fromSaveGame(minecraftInterface, saveGame);

--- a/src/main/java/amidst/mojangapi/minecraftinterface/LoggingMinecraftInterface.java
+++ b/src/main/java/amidst/mojangapi/minecraftinterface/LoggingMinecraftInterface.java
@@ -7,23 +7,17 @@ import amidst.mojangapi.world.WorldType;
 @ThreadSafe
 public class LoggingMinecraftInterface implements MinecraftInterface {
 	private final MinecraftInterface inner;
-	
+
 	public LoggingMinecraftInterface(MinecraftInterface minecraftInterface) {
 		this.inner = minecraftInterface;
 	}
 
 	@Override
-	public int[] getBiomeData(int x, int y, int width, int height, boolean useQuarterResolution)
-			throws MinecraftInterfaceException {
-		return inner.getBiomeData(x, y, width, height, useQuarterResolution);
-	}
-
-	@Override
-	public void createWorld(long seed, WorldType worldType, String generatorOptions)
+	public MinecraftInterface.World createWorld(long seed, WorldType worldType, String generatorOptions)
 			throws MinecraftInterfaceException {
 		AmidstLogger.info("Creating world with seed '{}' and type '{}'", seed, worldType.getName());
 		AmidstLogger.info("Using the following generator options: {}", generatorOptions);
-		inner.createWorld(seed, worldType, generatorOptions);
+		return inner.createWorld(seed, worldType, generatorOptions);
 	}
 
 	@Override

--- a/src/main/java/amidst/mojangapi/minecraftinterface/MinecraftInterface.java
+++ b/src/main/java/amidst/mojangapi/minecraftinterface/MinecraftInterface.java
@@ -7,34 +7,37 @@ import amidst.mojangapi.world.WorldType;
  * Acts as an additional layer of abstraction for interfacing with Minecraft.
  * This allows for other sources of data other than direct reflection against a
  * loaded jar of Minecraft.
- * 
+ *
  * Implementing classes need to be thread-safe!
- * 
- * One minecraft interface can only handle one world at a time.
  */
 @ThreadSafe
 public interface MinecraftInterface {
-	/**
-	 * @param useQuarterResolution Minecraft calculates biomes at
-	 *            quarter-resolution, then noisily interpolates the biome-map up
-	 *            to 1:1 resolution when needed, set useQuarterResolutionMap to
-	 *            true to read from the quarter-resolution map, or false to read
-	 *            values that have been interpolated up to full resolution.
-	 * 
-	 *            When useQuarterResolution is true, the x, y, width, and height
-	 *            paramaters must all correspond to a quarter of the Minecraft
-	 *            block coordinates/sizes you wish to obtain the biome data for.
-	 * 
-	 *            Amidst displays the quarter-resolution biome map, however full
-	 *            resolution is required to determine the position and nature of
-	 *            structures, as the noisy interpolation can change which biome
-	 *            a structure is located in (if the structure is located on a
-	 *            biome boundary).
-	 */
-	public int[] getBiomeData(int x, int y, int width, int height, boolean useQuarterResolution)
-			throws MinecraftInterfaceException;
 
-	public void createWorld(long seed, WorldType worldType, String generatorOptions) throws MinecraftInterfaceException;
+	public World createWorld(long seed, WorldType worldType, String generatorOptions) throws MinecraftInterfaceException;
 
 	public RecognisedVersion getRecognisedVersion();
+
+	@ThreadSafe
+	public static interface World {
+
+		/**
+		 * @param useQuarterResolution Minecraft calculates biomes at
+		 *            quarter-resolution, then noisily interpolates the biome-map up
+		 *            to 1:1 resolution when needed, set useQuarterResolutionMap to
+		 *            true to read from the quarter-resolution map, or false to read
+		 *            values that have been interpolated up to full resolution.
+		 *
+		 *            When useQuarterResolution is true, the x, y, width, and height
+		 *            paramaters must all correspond to a quarter of the Minecraft
+		 *            block coordinates/sizes you wish to obtain the biome data for.
+		 *
+		 *            Amidst displays the quarter-resolution biome map, however full
+		 *            resolution is required to determine the position and nature of
+		 *            structures, as the noisy interpolation can change which biome
+		 *            a structure is located in (if the structure is located on a
+		 *            biome boundary).
+		 */
+		public int[] getBiomeData(int x, int y, int width, int height, boolean useQuarterResolution)
+				throws MinecraftInterfaceException;
+	}
 }

--- a/src/main/java/amidst/mojangapi/minecraftinterface/MinecraftInterface.java
+++ b/src/main/java/amidst/mojangapi/minecraftinterface/MinecraftInterface.java
@@ -1,5 +1,7 @@
 package amidst.mojangapi.minecraftinterface;
 
+import java.util.function.Function;
+
 import amidst.documentation.ThreadSafe;
 import amidst.mojangapi.world.WorldType;
 
@@ -36,8 +38,13 @@ public interface MinecraftInterface {
 		 *            structures, as the noisy interpolation can change which biome
 		 *            a structure is located in (if the structure is located on a
 		 *            biome boundary).
+		 *
+		 * The biomeDataMapper callback is called with the biome data as an argument;
+		 * this array is only valid for the scope of the closure and should not escape it.
+		 * Any attempt to read the array once the callback returned may return wrong data.
 		 */
-		public int[] getBiomeData(int x, int y, int width, int height, boolean useQuarterResolution)
+		public<T> T getBiomeData(int x, int y, int width, int height,
+				boolean useQuarterResolution, Function<int[], T> biomeDataMapper)
 				throws MinecraftInterfaceException;
 	}
 }

--- a/src/main/java/amidst/mojangapi/minecraftinterface/MinecraftInterface.java
+++ b/src/main/java/amidst/mojangapi/minecraftinterface/MinecraftInterface.java
@@ -19,10 +19,19 @@ public interface MinecraftInterface {
 
 	public RecognisedVersion getRecognisedVersion();
 
+	/**
+	 * Represents a Minecraft world, allowing for querying of biome data.
+	 *
+	 * Implementing classes need to be thread-safe!
+	 */
 	@ThreadSafe
 	public static interface World {
 
 		/**
+		 * Calling this method from different threads must be valid, but implementations
+		 * may allow only one thread to progress at any given moment. To ensure true
+		 * concurrency, it is best to obtain a separate World object for each thread.
+		 *
 		 * @param useQuarterResolution Minecraft calculates biomes at
 		 *            quarter-resolution, then noisily interpolates the biome-map up
 		 *            to 1:1 resolution when needed, set useQuarterResolutionMap to
@@ -39,9 +48,10 @@ public interface MinecraftInterface {
 		 *            a structure is located in (if the structure is located on a
 		 *            biome boundary).
 		 *
-		 * The biomeDataMapper callback is called with the biome data as an argument;
-		 * this array is only valid for the scope of the closure and should not escape it.
-		 * Any attempt to read the array once the callback returned may return wrong data.
+		 * @param biomeDataMapper This callback is called with the biome data as an
+		 *            argument; this array is only valid for the scope of the closure
+		 *            and should not escape it. Any attempt to read the array once
+		 *            the callback returned may return invalid data.
 		 */
 		public<T> T getBiomeData(int x, int y, int width, int height,
 				boolean useQuarterResolution, Function<int[], T> biomeDataMapper)

--- a/src/main/java/amidst/mojangapi/minecraftinterface/legacy/LegacyMinecraftInterface.java
+++ b/src/main/java/amidst/mojangapi/minecraftinterface/legacy/LegacyMinecraftInterface.java
@@ -26,6 +26,8 @@ public class LegacyMinecraftInterface implements MinecraftInterface {
 	private final SymbolicClass genOptionsFactoryClass;
 	private final RecognisedVersion recognisedVersion;
 
+	private boolean isIntCacheInUse = false;
+
 	LegacyMinecraftInterface(
 			SymbolicClass intCacheClass,
 			SymbolicClass blockInitClass,
@@ -51,34 +53,26 @@ public class LegacyMinecraftInterface implements MinecraftInterface {
 			recognisedVersion);
 	}
 
-	/*@Override
-	public synchronized int[] getBiomeData(int x, int y, int width, int height, boolean useQuarterResolution)
+	// Only one thread can manipulate the Minecraft int cache at a time
+	private synchronized int[] getBiomeData(int x, int y, int width, int height, SymbolicObject biomeGenerator)
 			throws MinecraftInterfaceException {
+		if (isIntCacheInUse) {
+			throw new IllegalStateException("This thread is already generating biome data");
+		}
+		isIntCacheInUse = true;
 		try {
 			intCacheClass.callStaticMethod(LegacySymbolicNames.METHOD_INT_CACHE_RESET_INT_CACHE);
-			return (int[]) getBiomeGenerator(useQuarterResolution)
-					.callMethod(LegacySymbolicNames.METHOD_GEN_LAYER_GET_INTS, x, y, width, height);
+			return (int[]) biomeGenerator
+				.callMethod(LegacySymbolicNames.METHOD_GEN_LAYER_GET_INTS, x, y, width, height);
 		} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
 			throw new MinecraftInterfaceException("unable to get biome data", e);
-		}
-	}*/
-
-	private int[] getBiomeData(int x, int y, int width, int height, SymbolicObject biomeGenerator)
-			throws MinecraftInterfaceException {
-		try {
-			// Only one thread can manipulate the Minecraft int cache at a time
-			synchronized (intCacheClass) {
-				intCacheClass.callStaticMethod(LegacySymbolicNames.METHOD_INT_CACHE_RESET_INT_CACHE);
-				return (int[]) biomeGenerator
-						.callMethod(LegacySymbolicNames.METHOD_GEN_LAYER_GET_INTS, x, y, width, height);
-			}
-		} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
-			throw new MinecraftInterfaceException("unable to get biome data", e);
+		} finally {
+			isIntCacheInUse = false;
 		}
 	}
 
 	@Override
-	public synchronized World createWorld(long seed, WorldType worldType, String generatorOptions)
+	public World createWorld(long seed, WorldType worldType, String generatorOptions)
 			throws MinecraftInterfaceException {
 		try {
 			initializeBlock();
@@ -95,7 +89,7 @@ public class LegacyMinecraftInterface implements MinecraftInterface {
 	 * Minecraft 1.8 and higher require block initialization to be called before
 	 * creating a biome generator.
 	 */
-	private void initializeBlock() throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+	private synchronized void initializeBlock() throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
 		if (blockInitClass != null) {
 			blockInitClass.callStaticMethod(LegacySymbolicNames.METHOD_BLOCK_INIT_INITIALIZE);
 		}

--- a/src/main/java/amidst/mojangapi/minecraftinterface/legacy/LegacyMinecraftInterface.java
+++ b/src/main/java/amidst/mojangapi/minecraftinterface/legacy/LegacyMinecraftInterface.java
@@ -2,6 +2,7 @@ package amidst.mojangapi.minecraftinterface.legacy;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
+import java.util.function.Function;
 
 import amidst.clazz.symbolic.SymbolicClass;
 import amidst.clazz.symbolic.SymbolicObject;
@@ -155,10 +156,12 @@ public class LegacyMinecraftInterface implements MinecraftInterface {
 		}
 
 		@Override
-		public int[] getBiomeData(int x, int y, int width, int height, boolean useQuarterResolution)
+		public<T> T getBiomeData(int x, int y, int width, int height,
+				boolean useQuarterResolution, Function<int[], T> biomeDataMapper)
 				throws MinecraftInterfaceException {
 			SymbolicObject biomeGenerator = useQuarterResolution ? quarterResolutionBiomeGenerator : fullResolutionBiomeGenerator;
-			return LegacyMinecraftInterface.this.getBiomeData(x, y, width, height, biomeGenerator);
+			int[] data = LegacyMinecraftInterface.this.getBiomeData(x, y, width, height, biomeGenerator);
+			return biomeDataMapper.apply(data);
 		}
 	}
 }

--- a/src/main/java/amidst/mojangapi/minecraftinterface/legacy/_1_13MinecraftInterface.java
+++ b/src/main/java/amidst/mojangapi/minecraftinterface/legacy/_1_13MinecraftInterface.java
@@ -44,27 +44,6 @@ public class _1_13MinecraftInterface implements MinecraftInterface {
 	 */
 	private Object biomeRegistry;
 
-	/**
-	 * A GenLayer instance, at quarter scale to the final biome layer (i.e. both
-	 * axis are divided by 4). Minecraft calculates biomes at
-	 * quarter-resolution, then noisily interpolates the biome-map up to 1:1
-	 * resolution when needed, this is the biome GenLayer before it is
-	 * interpolated.
-	 */
-	private volatile SymbolicObject quarterResolutionBiomeGenerator;
-
-	/**
-	 * A GenLayer instance, the biome layer. (1:1 scale) Minecraft calculates
-	 * biomes at quarter-resolution, then noisily interpolates the biome-map up
-	 * to 1:1 resolution when needed, this is the interpolated biome GenLayer.
-	 */
-	private volatile SymbolicObject fullResolutionBiomeGenerator;
-
-	/**
-	 * An array used to return biome data
-	 */
-	private volatile ArrayCache<int[]> dataArray = ArrayCache.makeIntArrayCache(256);
-
 	public _1_13MinecraftInterface(
 			SymbolicClass bootstrapClass,
 			SymbolicClass worldTypeClass,
@@ -100,15 +79,10 @@ public class _1_13MinecraftInterface implements MinecraftInterface {
 				recognisedVersion);
 	}
 
-	@Override
-	public int[] getBiomeData(int x, int y, int width, int height, boolean useQuarterResolution)
+	private int[] populateBiomeData(int[] data, int x, int y, int width, int height, SymbolicObject biomeGen)
 			throws MinecraftInterfaceException {
 		try {
-			if (biomeGetIdMethod == null) {
-				biomeGetIdMethod = getBiomeGetIdHandle();
-			}
-
-			int[] data = dataArray.getArray(width * height);
+			initBiomeGetIdHandle();
 
 			/**
 			 * We break the region in 16x16 chunks, to get better performance
@@ -117,7 +91,7 @@ public class _1_13MinecraftInterface implements MinecraftInterface {
 			 * we get a ~1.5x improvement.
 			 */
 			if (RecognisedVersion.isNewerOrEqualTo(recognisedVersion, RecognisedVersion._18w16a)) {
-				Object[] biomes = getBiomeDataInner(x, y, width, height, useQuarterResolution);
+				Object[] biomes = getBiomeDataInner(x, y, width, height, biomeGen);
 				for (int i = 0; i < biomes.length; i++) {
 					data[i] = getBiomeId(biomes[i]);
 				}
@@ -129,7 +103,7 @@ public class _1_13MinecraftInterface implements MinecraftInterface {
 					for (int y0 = 0; y0 < height; y0 += chunkSize) {
 						int h = Math.min(chunkSize, height - y0);
 
-						Object[] biomes = getBiomeDataInner(x + x0, y + y0, w, h, useQuarterResolution);
+						Object[] biomes = getBiomeDataInner(x + x0, y + y0, w, h, biomeGen);
 
 						for (int i = 0; i < w; i++) {
 							for (int j = 0; j < h; j++) {
@@ -151,33 +125,33 @@ public class _1_13MinecraftInterface implements MinecraftInterface {
 		}
 	}
 
-	private Object[] getBiomeDataInner(int x, int y, int width, int height, boolean useQuarterResolution)
+	private Object[] getBiomeDataInner(int x, int y, int width, int height, SymbolicObject biomeGen)
 			throws IllegalAccessException,
 			IllegalArgumentException,
 			InvocationTargetException {
-		SymbolicObject biomeGen = getBiomeGenerator(useQuarterResolution);
-		Object[] biomes = null;
 		if(genLayerClass.hasMethod(_1_13SymbolicNames.METHOD_GEN_LAYER_GET_BIOME_DATA)) {
-			biomes = (Object[]) biomeGen.callMethod(
+			return (Object[]) biomeGen.callMethod(
 					_1_13SymbolicNames.METHOD_GEN_LAYER_GET_BIOME_DATA, x, y, width, height, null);
 		} else {
-			biomes = (Object[]) biomeGen.callMethod(
+			return (Object[]) biomeGen.callMethod(
 					_1_13SymbolicNames.METHOD_GEN_LAYER_GET_BIOME_DATA2, x, y, width, height);
 		}
-		return biomes;
 	}
 
-	private MethodHandle getBiomeGetIdHandle()
+	private synchronized void initBiomeGetIdHandle()
 			throws IllegalArgumentException,
 			IllegalAccessException,
 			InstantiationException,
 			InvocationTargetException {
+		if (biomeGetIdMethod != null) {
+			return;
+		}
 		Method biomeRawMethod = biomeClass.getMethod(_1_13SymbolicNames.METHOD_BIOME_GET_ID).getRawMethod();
 		if (registryKeyClass != null && !biomeRawMethod.getReturnType().equals(Integer.TYPE)) {
 			biomeRegistry = getBiomeRegistry();
 			biomeRawMethod = registryClass.getMethod(_1_13SymbolicNames.METHOD_REGISTRY_GET_ID).getRawMethod();
 		}
-		return MethodHandles.lookup().unreflect(biomeRawMethod);
+		biomeGetIdMethod = MethodHandles.lookup().unreflect(biomeRawMethod);
 	}
 
 	private Object getBiomeRegistry()
@@ -201,14 +175,11 @@ public class _1_13MinecraftInterface implements MinecraftInterface {
 	}
 
 	@Override
-	public synchronized void createWorld(long seed, WorldType worldType, String generatorOptions)
+	public synchronized MinecraftInterface.World createWorld(long seed, WorldType worldType, String generatorOptions)
 			throws MinecraftInterfaceException {
 
 		try {
-			if (!isBootstrapCalled) {
-				callBootstrapRegister();
-				isBootstrapCalled = true;
-			}
+			callBootstrapRegister();
 
 			// @formatter:off
 			Object[] genLayers = (Object[]) layerUtilClass.callStaticMethod(
@@ -219,8 +190,9 @@ public class _1_13MinecraftInterface implements MinecraftInterface {
 			);
 			// @formatter:on
 
-			quarterResolutionBiomeGenerator = new SymbolicObject(genLayerClass, genLayers[0]);
-			fullResolutionBiomeGenerator = new SymbolicObject(genLayerClass, genLayers[1]);
+			SymbolicObject quarterResolutionGen = new SymbolicObject(genLayerClass, genLayers[0]);
+			SymbolicObject fullResolutionGen = new SymbolicObject(genLayerClass, genLayers[1]);
+			return new World(quarterResolutionGen, fullResolutionGen);
 
 		} catch (
 				IllegalAccessException
@@ -231,10 +203,14 @@ public class _1_13MinecraftInterface implements MinecraftInterface {
 		}
 	}
 
-	private void callBootstrapRegister()
+	private synchronized void callBootstrapRegister()
 			throws IllegalAccessException,
 			IllegalArgumentException,
 			InvocationTargetException {
+		if (isBootstrapCalled) {
+			return;
+		}
+
 		String register = _1_13SymbolicNames.METHOD_BOOTSTRAP_REGISTER;
 		if(RecognisedVersion.isNewer(recognisedVersion, RecognisedVersion._1_13_2)) {
 			if(bootstrapClass.getMethod(_1_13SymbolicNames.METHOD_BOOTSTRAP_REGISTER3).hasModifiers(Modifier.PUBLIC)) {
@@ -245,14 +221,7 @@ public class _1_13MinecraftInterface implements MinecraftInterface {
 		}
 
 		bootstrapClass.callStaticMethod(register);
-	}
-
-	private SymbolicObject getBiomeGenerator(boolean useQuarterResolution) {
-		if (useQuarterResolution) {
-			return quarterResolutionBiomeGenerator;
-		} else {
-			return fullResolutionBiomeGenerator;
-		}
+		isBootstrapCalled = true;
 	}
 
 	private SymbolicObject getWorldType(WorldType worldType) throws IllegalArgumentException, IllegalAccessException {
@@ -288,4 +257,39 @@ public class _1_13MinecraftInterface implements MinecraftInterface {
 		return recognisedVersion;
 	}
 
+	private class World implements MinecraftInterface.World {
+		/**
+		 * A GenLayer instance, at quarter scale to the final biome layer (i.e. both
+		 * axis are divided by 4). Minecraft calculates biomes at
+		 * quarter-resolution, then noisily interpolates the biome-map up to 1:1
+		 * resolution when needed, this is the biome GenLayer before it is
+		 * interpolated.
+		 */
+		private volatile SymbolicObject quarterResolutionBiomeGenerator;
+
+		/**
+		 * A GenLayer instance, the biome layer. (1:1 scale) Minecraft calculates
+		 * biomes at quarter-resolution, then noisily interpolates the biome-map up
+		 * to 1:1 resolution when needed, this is the interpolated biome GenLayer.
+		 */
+		private volatile SymbolicObject fullResolutionBiomeGenerator;
+
+		/**
+		 * An array used to return biome data
+		 */
+		private volatile ArrayCache<int[]> dataArray = ArrayCache.makeIntArrayCache(256);
+
+		private World(SymbolicObject quarterResolutionGen, SymbolicObject fullResolutionGen) {
+			this.quarterResolutionBiomeGenerator = quarterResolutionGen;
+			this.fullResolutionBiomeGenerator = fullResolutionGen;
+		}
+
+		@Override
+		public int[] getBiomeData(int x, int y, int width, int height, boolean useQuarterResolution)
+				throws MinecraftInterfaceException {
+			SymbolicObject biomeGenerator = useQuarterResolution ? quarterResolutionBiomeGenerator : fullResolutionBiomeGenerator;
+			int[] data = dataArray.getArray(width * height);
+			return populateBiomeData(data, x, y, width, height, biomeGenerator);
+		}
+	}
 }

--- a/src/main/java/amidst/mojangapi/minecraftinterface/legacy/_1_13MinecraftInterface.java
+++ b/src/main/java/amidst/mojangapi/minecraftinterface/legacy/_1_13MinecraftInterface.java
@@ -14,6 +14,7 @@ import amidst.mojangapi.minecraftinterface.MinecraftInterface;
 import amidst.mojangapi.minecraftinterface.MinecraftInterfaceException;
 import amidst.mojangapi.minecraftinterface.RecognisedVersion;
 import amidst.mojangapi.world.WorldType;
+import amidst.util.ArrayCache;
 
 public class _1_13MinecraftInterface implements MinecraftInterface {
     public static final RecognisedVersion LAST_COMPATIBLE_VERSION = RecognisedVersion._19w35a;
@@ -59,6 +60,11 @@ public class _1_13MinecraftInterface implements MinecraftInterface {
 	 */
 	private volatile SymbolicObject fullResolutionBiomeGenerator;
 
+	/**
+	 * An array used to return biome data
+	 */
+	private volatile ArrayCache<int[]> dataArray = ArrayCache.makeIntArrayCache(256);
+
 	public _1_13MinecraftInterface(
 			SymbolicClass bootstrapClass,
 			SymbolicClass worldTypeClass,
@@ -101,8 +107,8 @@ public class _1_13MinecraftInterface implements MinecraftInterface {
 			if (biomeGetIdMethod == null) {
 				biomeGetIdMethod = getBiomeGetIdHandle();
 			}
-			
-			int[] data = new int[width * height];
+
+			int[] data = dataArray.getArray(width * height);
 
 			/**
 			 * We break the region in 16x16 chunks, to get better performance

--- a/src/main/java/amidst/mojangapi/minecraftinterface/legacy/_1_13MinecraftInterface.java
+++ b/src/main/java/amidst/mojangapi/minecraftinterface/legacy/_1_13MinecraftInterface.java
@@ -6,6 +6,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Map;
+import java.util.function.Function;
 
 import amidst.clazz.symbolic.SymbolicClass;
 import amidst.clazz.symbolic.SymbolicObject;
@@ -285,11 +286,13 @@ public class _1_13MinecraftInterface implements MinecraftInterface {
 		}
 
 		@Override
-		public int[] getBiomeData(int x, int y, int width, int height, boolean useQuarterResolution)
+		public<T> T getBiomeData(int x, int y, int width, int height,
+				boolean useQuarterResolution, Function<int[], T> biomeDataMapper)
 				throws MinecraftInterfaceException {
 			SymbolicObject biomeGenerator = useQuarterResolution ? quarterResolutionBiomeGenerator : fullResolutionBiomeGenerator;
 			int[] data = dataArray.getArray(width * height);
-			return populateBiomeData(data, x, y, width, height, biomeGenerator);
+			populateBiomeData(data, x, y, width, height, biomeGenerator);
+			return biomeDataMapper.apply(data);
 		}
 	}
 }

--- a/src/main/java/amidst/mojangapi/minecraftinterface/local/LocalMinecraftInterface.java
+++ b/src/main/java/amidst/mojangapi/minecraftinterface/local/LocalMinecraftInterface.java
@@ -193,7 +193,6 @@ public class LocalMinecraftInterface implements MinecraftInterface {
 	    	this.seedForBiomeZoomer = seedForBiomeZoomer;
 	    }
 
-
 		@Override
 		public<T> T getBiomeData(int x, int y, int width, int height,
 				boolean useQuarterResolution, Function<int[], T> biomeDataMapper)

--- a/src/main/java/amidst/mojangapi/minecraftinterface/local/LocalMinecraftInterface.java
+++ b/src/main/java/amidst/mojangapi/minecraftinterface/local/LocalMinecraftInterface.java
@@ -40,6 +40,11 @@ public class LocalMinecraftInterface implements MinecraftInterface {
 	private Object biomeRegistry;
 	private Object biomeProviderRegistry;
 
+    /**
+     * An array used to return biome data
+     */
+    private final ArrayCache<int[]> dataArray = ArrayCache.makeIntArrayCache(256);
+
 	public LocalMinecraftInterface(Map<String, SymbolicClass> symbolicClassMap, RecognisedVersion recognisedVersion) {
 		this.recognisedVersion = recognisedVersion;
 		this.registryClass = symbolicClassMap.get(SymbolicNames.CLASS_REGISTRY);
@@ -182,11 +187,6 @@ public class LocalMinecraftInterface implements MinecraftInterface {
 	     */
 		private long seedForBiomeZoomer;
 
-	    /**
-	     * An array used to return biome data
-	     */
-	    private volatile ArrayCache<int[]> dataArray = ArrayCache.makeIntArrayCache(256);
-
 	    private World(Object biomeProvider, Object biomeZoomer, long seedForBiomeZoomer) {
 	    	this.biomeProvider = biomeProvider;
 	    	this.biomeZoomer = biomeZoomer;
@@ -198,39 +198,40 @@ public class LocalMinecraftInterface implements MinecraftInterface {
 		public<T> T getBiomeData(int x, int y, int width, int height,
 				boolean useQuarterResolution, Function<int[], T> biomeDataMapper)
 				throws MinecraftInterfaceException {
+
 			int size = width * height;
-		    int[] data = dataArray.getArray(size);
+		    return dataArray.withArrayFaillible(size, data -> {
+			    try {
+			    	if(size == 1) {
+			    		data[0] = getBiomeIdAt(x, y, useQuarterResolution);
+			    		return biomeDataMapper.apply(data);
+			    	}
 
-		    try {
-		    	if(size == 1) {
-		    		data[0] = getBiomeIdAt(x, y, useQuarterResolution);
-		    		return biomeDataMapper.apply(data);
-		    	}
+			        /**
+			         * We break the region in 16x16 chunks, to get better performance out
+			         * of the LazyArea used by the game. This gives a ~2x improvement.
+		             */
+		            int chunkSize = 16;
+		            for (int x0 = 0; x0 < width; x0 += chunkSize) {
+		                int w = Math.min(chunkSize, width - x0);
 
-		        /**
-		         * We break the region in 16x16 chunks, to get better performance out
-		         * of the LazyArea used by the game. This gives a ~2x improvement.
-	             */
-	            int chunkSize = 16;
-	            for (int x0 = 0; x0 < width; x0 += chunkSize) {
-	                int w = Math.min(chunkSize, width - x0);
+		                for (int y0 = 0; y0 < height; y0 += chunkSize) {
+		                    int h = Math.min(chunkSize, height - y0);
 
-	                for (int y0 = 0; y0 < height; y0 += chunkSize) {
-	                    int h = Math.min(chunkSize, height - y0);
+		                    for (int i = 0; i < w; i++) {
+		                        for (int j = 0; j < h; j++) {
+		                            int trueIdx = (x0 + i) + (y0 + j) * width;
+		                            data[trueIdx] = getBiomeIdAt(x + x0 + i, y + y0 + j, useQuarterResolution);
+		                        }
+		                    }
+		                }
+		            }
+			    } catch (Throwable e) {
+			        throw new MinecraftInterfaceException("unable to get biome data", e);
+			    }
 
-	                    for (int i = 0; i < w; i++) {
-	                        for (int j = 0; j < h; j++) {
-	                            int trueIdx = (x0 + i) + (y0 + j) * width;
-	                            data[trueIdx] = getBiomeIdAt(x + x0 + i, y + y0 + j, useQuarterResolution);
-	                        }
-	                    }
-	                }
-	            }
-		    } catch (Throwable e) {
-		        throw new MinecraftInterfaceException("unable to get biome data", e);
-		    }
-
-		    return biomeDataMapper.apply(data);
+			    return biomeDataMapper.apply(data);
+		    });
 		}
 
 		private int getBiomeIdAt(int x, int y, boolean useQuarterResolution) throws Throwable {

--- a/src/main/java/amidst/mojangapi/minecraftinterface/local/LocalMinecraftInterface.java
+++ b/src/main/java/amidst/mojangapi/minecraftinterface/local/LocalMinecraftInterface.java
@@ -39,28 +39,6 @@ public class LocalMinecraftInterface implements MinecraftInterface {
 	private Object biomeRegistry;
 	private Object biomeProviderRegistry;
 
-	/**
-	 * A BiomeProvider instance for the current world, giving
-	 * access to the quarter-scale biome data.
-	 */
-    private Object biomeProvider;
-    /**
-     * The BiomeZoomer instance for the current world, which
-     * interpolates the quarter-scale BiomeProvider to give
-     * full-scale biome data.
-     */
-    private Object biomeZoomer;
-    /**
-     * The seed used by the BiomeZoomer during interpolation.
-     * It is derived from the world seed.
-     */
-	private long seedForBiomeZoomer;
-
-    /**
-     * An array used to return biome data
-     */
-    private volatile ArrayCache<int[]> dataArray = ArrayCache.makeIntArrayCache(256);
-
 	public LocalMinecraftInterface(Map<String, SymbolicClass> symbolicClassMap, RecognisedVersion recognisedVersion) {
 		this.recognisedVersion = recognisedVersion;
 		this.registryClass = symbolicClassMap.get(SymbolicNames.CLASS_REGISTRY);
@@ -75,69 +53,16 @@ public class LocalMinecraftInterface implements MinecraftInterface {
 	}
 
 	@Override
-	public int[] getBiomeData(int x, int y, int width, int height, boolean useQuarterResolution)
-			throws MinecraftInterfaceException {
-	    if (!isInitialized || biomeProvider == null || biomeZoomer == null) {
-	        throw new MinecraftInterfaceException("no world was created");
-	    }
-
-	    int size = width * height;
-	    int[] data = dataArray.getArray(width * height);
-
-	    try {
-
-	    	if(size == 1) {
-	    		data[0] = getBiomeIdAt(x, y, useQuarterResolution);
-	    	} else {
-		        /**
-		         * We break the region in 16x16 chunks, to get better performance out
-		         * of the LazyArea used by the game. This gives a ~2x improvement.
-	             */
-	            int chunkSize = 16;
-	            for (int x0 = 0; x0 < width; x0 += chunkSize) {
-	                int w = Math.min(chunkSize, width - x0);
-
-	                for (int y0 = 0; y0 < height; y0 += chunkSize) {
-	                    int h = Math.min(chunkSize, height - y0);
-
-	                    for (int i = 0; i < w; i++) {
-	                        for (int j = 0; j < h; j++) {
-	                            int trueIdx = (x0 + i) + (y0 + j) * width;
-	                            data[trueIdx] = getBiomeIdAt(x + x0 + i, y + y0 + j, useQuarterResolution);
-	                        }
-	                    }
-	                }
-	            }
-	    	}
-	    } catch (Throwable e) {
-	        throw new MinecraftInterfaceException("unable to get biome data", e);
-	    }
-
-	    return data;
-	}
-
-	private int getBiomeIdAt(int x, int y, boolean useQuarterResolution) throws Throwable {
-	    Object biome;
-        // We don't care about the vertical component, so we pass a bogus value
-	    int height = -9999;
-	    if(useQuarterResolution) {
-	        biome = biomeProviderGetBiomeMethod.invoke(biomeProvider, x, height, y);
-	    } else {
-	        biome = biomeZoomerGetBiomeMethod.invoke(biomeZoomer, seedForBiomeZoomer, x, height, y, biomeProvider);
-	    }
-	    return (int) registryGetIdMethod.invoke(biomeRegistry, biome);
-	}
-
-	@Override
-	public synchronized void createWorld(long seed, WorldType worldType, String generatorOptions)
+	public synchronized MinecraftInterface.World createWorld(long seed, WorldType worldType, String generatorOptions)
 			throws MinecraftInterfaceException {
 	    initializeIfNeeded();
 
 	    try {
 	        Object worldData = createWorldDataObject(seed, worldType, generatorOptions);
-	        biomeProvider = createBiomeProviderObject(worldData);
-	        biomeZoomer = overworldBiomeZoomerClass.getClazz().getEnumConstants()[0];
-            seedForBiomeZoomer = (Long) worldDataClass.callStaticMethod(SymbolicNames.METHOD_WORLD_DATA_MAP_SEED, seed);
+	        Object biomeProvider = createBiomeProviderObject(worldData);
+	        Object biomeZoomer = overworldBiomeZoomerClass.getClazz().getEnumConstants()[0];
+            long seedForBiomeZoomer = (Long) worldDataClass.callStaticMethod(SymbolicNames.METHOD_WORLD_DATA_MAP_SEED, seed);
+            return new World(biomeProvider, biomeZoomer, seedForBiomeZoomer);
 
         } catch(IllegalArgumentException | IllegalAccessException | InstantiationException | InvocationTargetException e) {
             throw new MinecraftInterfaceException("unable to create world", e);
@@ -195,7 +120,7 @@ public class LocalMinecraftInterface implements MinecraftInterface {
 		return recognisedVersion;
 	}
 
-	private void initializeIfNeeded() throws MinecraftInterfaceException {
+	private synchronized void initializeIfNeeded() throws MinecraftInterfaceException {
 	    if (isInitialized) {
 	        return;
 	    }
@@ -236,5 +161,86 @@ public class LocalMinecraftInterface implements MinecraftInterface {
 	private MethodHandle getMethodHandle(SymbolicClass symbolicClass, String method) throws IllegalAccessException {
 	    Method rawMethod = symbolicClass.getMethod(method).getRawMethod();
 	    return MethodHandles.lookup().unreflect(rawMethod);
+	}
+
+	private class World implements MinecraftInterface.World {
+		/**
+		 * A BiomeProvider instance for the current world, giving
+		 * access to the quarter-scale biome data.
+		 */
+	    private Object biomeProvider;
+	    /**
+	     * The BiomeZoomer instance for the current world, which
+	     * interpolates the quarter-scale BiomeProvider to give
+	     * full-scale biome data.
+	     */
+	    private Object biomeZoomer;
+	    /**
+	     * The seed used by the BiomeZoomer during interpolation.
+	     * It is derived from the world seed.
+	     */
+		private long seedForBiomeZoomer;
+
+	    /**
+	     * An array used to return biome data
+	     */
+	    private volatile ArrayCache<int[]> dataArray = ArrayCache.makeIntArrayCache(256);
+
+	    private World(Object biomeProvider, Object biomeZoomer, long seedForBiomeZoomer) {
+	    	this.biomeProvider = biomeProvider;
+	    	this.biomeZoomer = biomeZoomer;
+	    	this.seedForBiomeZoomer = seedForBiomeZoomer;
+	    }
+
+
+		@Override
+		public int[] getBiomeData(int x, int y, int width, int height, boolean useQuarterResolution)
+				throws MinecraftInterfaceException {
+			int size = width * height;
+		    int[] data = dataArray.getArray(size);
+
+		    try {
+		    	if(size == 1) {
+		    		data[0] = getBiomeIdAt(x, y, useQuarterResolution);
+		    		return data;
+		    	}
+
+		        /**
+		         * We break the region in 16x16 chunks, to get better performance out
+		         * of the LazyArea used by the game. This gives a ~2x improvement.
+	             */
+	            int chunkSize = 16;
+	            for (int x0 = 0; x0 < width; x0 += chunkSize) {
+	                int w = Math.min(chunkSize, width - x0);
+
+	                for (int y0 = 0; y0 < height; y0 += chunkSize) {
+	                    int h = Math.min(chunkSize, height - y0);
+
+	                    for (int i = 0; i < w; i++) {
+	                        for (int j = 0; j < h; j++) {
+	                            int trueIdx = (x0 + i) + (y0 + j) * width;
+	                            data[trueIdx] = getBiomeIdAt(x + x0 + i, y + y0 + j, useQuarterResolution);
+	                        }
+	                    }
+	                }
+	            }
+		    } catch (Throwable e) {
+		        throw new MinecraftInterfaceException("unable to get biome data", e);
+		    }
+
+		    return data;
+		}
+
+		private int getBiomeIdAt(int x, int y, boolean useQuarterResolution) throws Throwable {
+		    Object biome;
+	        // We don't care about the vertical component, so we pass a bogus value
+		    int height = -9999;
+		    if(useQuarterResolution) {
+		        biome = biomeProviderGetBiomeMethod.invoke(biomeProvider, x, height, y);
+		    } else {
+		        biome = biomeZoomerGetBiomeMethod.invoke(biomeZoomer, seedForBiomeZoomer, x, height, y, biomeProvider);
+		    }
+		    return (int) registryGetIdMethod.invoke(biomeRegistry, biome);
+		}
 	}
 }

--- a/src/main/java/amidst/mojangapi/minecraftinterface/local/LocalMinecraftInterface.java
+++ b/src/main/java/amidst/mojangapi/minecraftinterface/local/LocalMinecraftInterface.java
@@ -7,6 +7,7 @@ import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Function;
 
 import amidst.clazz.symbolic.SymbolicClass;
 import amidst.clazz.symbolic.SymbolicObject;
@@ -194,7 +195,8 @@ public class LocalMinecraftInterface implements MinecraftInterface {
 
 
 		@Override
-		public int[] getBiomeData(int x, int y, int width, int height, boolean useQuarterResolution)
+		public<T> T getBiomeData(int x, int y, int width, int height,
+				boolean useQuarterResolution, Function<int[], T> biomeDataMapper)
 				throws MinecraftInterfaceException {
 			int size = width * height;
 		    int[] data = dataArray.getArray(size);
@@ -202,7 +204,7 @@ public class LocalMinecraftInterface implements MinecraftInterface {
 		    try {
 		    	if(size == 1) {
 		    		data[0] = getBiomeIdAt(x, y, useQuarterResolution);
-		    		return data;
+		    		return biomeDataMapper.apply(data);
 		    	}
 
 		        /**
@@ -228,7 +230,7 @@ public class LocalMinecraftInterface implements MinecraftInterface {
 		        throw new MinecraftInterfaceException("unable to get biome data", e);
 		    }
 
-		    return data;
+		    return biomeDataMapper.apply(data);
 		}
 
 		private int getBiomeIdAt(int x, int y, boolean useQuarterResolution) throws Throwable {

--- a/src/main/java/amidst/mojangapi/minecraftinterface/local/LocalMinecraftInterface.java
+++ b/src/main/java/amidst/mojangapi/minecraftinterface/local/LocalMinecraftInterface.java
@@ -15,6 +15,7 @@ import amidst.mojangapi.minecraftinterface.MinecraftInterface;
 import amidst.mojangapi.minecraftinterface.MinecraftInterfaceException;
 import amidst.mojangapi.minecraftinterface.RecognisedVersion;
 import amidst.mojangapi.world.WorldType;
+import amidst.util.ArrayCache;
 
 public class LocalMinecraftInterface implements MinecraftInterface {
 
@@ -55,6 +56,11 @@ public class LocalMinecraftInterface implements MinecraftInterface {
      */
 	private long seedForBiomeZoomer;
 
+    /**
+     * An array used to return biome data
+     */
+    private volatile ArrayCache<int[]> dataArray = ArrayCache.makeIntArrayCache(256);
+
 	public LocalMinecraftInterface(Map<String, SymbolicClass> symbolicClassMap, RecognisedVersion recognisedVersion) {
 		this.recognisedVersion = recognisedVersion;
 		this.registryClass = symbolicClassMap.get(SymbolicNames.CLASS_REGISTRY);
@@ -76,11 +82,10 @@ public class LocalMinecraftInterface implements MinecraftInterface {
 	    }
 
 	    int size = width * height;
-
-	    int[] data = new int[size];
+	    int[] data = dataArray.getArray(width * height);
 
 	    try {
-	    	
+
 	    	if(size == 1) {
 	    		data[0] = getBiomeIdAt(x, y, useQuarterResolution);
 	    	} else {
@@ -91,10 +96,10 @@ public class LocalMinecraftInterface implements MinecraftInterface {
 	            int chunkSize = 16;
 	            for (int x0 = 0; x0 < width; x0 += chunkSize) {
 	                int w = Math.min(chunkSize, width - x0);
-	
+
 	                for (int y0 = 0; y0 < height; y0 += chunkSize) {
 	                    int h = Math.min(chunkSize, height - y0);
-	
+
 	                    for (int i = 0; i < w; i++) {
 	                        for (int j = 0; j < h; j++) {
 	                            int trueIdx = (x0 + i) + (y0 + j) * width;
@@ -203,7 +208,7 @@ public class LocalMinecraftInterface implements MinecraftInterface {
 			} catch (NullPointerException e) {
 				AmidstLogger.warn("Unable to shut down Server-Worker threads");
 			}
-			
+
             biomeRegistry = Objects.requireNonNull(getFromRegistryByKey(metaRegistry, "biome"));
             biomeProviderRegistry = Objects.requireNonNull(getFromRegistryByKey(metaRegistry, "biome_source_type"));
 

--- a/src/main/java/amidst/mojangapi/world/World.java
+++ b/src/main/java/amidst/mojangapi/world/World.java
@@ -1,7 +1,6 @@
 package amidst.mojangapi.world;
 
 import java.util.List;
-import java.util.function.Consumer;
 
 import amidst.documentation.ThreadSafe;
 import amidst.mojangapi.minecraftinterface.RecognisedVersion;
@@ -17,8 +16,6 @@ import amidst.mojangapi.world.player.MovablePlayerList;
 
 @ThreadSafe
 public class World {
-	private final Consumer<World> onDisposeWorld;
-
 	private final WorldOptions worldOptions;
 	private final MovablePlayerList movablePlayerList;
 	private final RecognisedVersion recognisedVersion;
@@ -41,7 +38,6 @@ public class World {
 	private final WorldIconProducer<List<EndIsland>> endCityProducer;
 
 	public World(
-			Consumer<World> onDisposeWorld,
 			WorldOptions worldOptions,
 			MovablePlayerList movablePlayerList,
 			RecognisedVersion recognisedVersion,
@@ -61,7 +57,6 @@ public class World {
 			WorldIconProducer<Void> oceanFeaturesProducer,
 			WorldIconProducer<Void> netherFortressProducer,
 			WorldIconProducer<List<EndIsland>> endCityProducer) {
-		this.onDisposeWorld = onDisposeWorld;
 		this.worldOptions = worldOptions;
 		this.movablePlayerList = movablePlayerList;
 		this.recognisedVersion = recognisedVersion;
@@ -173,14 +168,5 @@ public class World {
 
 	public void reloadPlayerWorldIcons() {
 		playerProducer.resetCache();
-	}
-
-	/**
-	 * Unlocks the RunningLauncherProfile to allow the creation of another
-	 * world. However, this does not actually prevent the usage of this world.
-	 * If you keep using it, something will break.
-	 */
-	public void dispose() {
-		onDisposeWorld.accept(this);
 	}
 }

--- a/src/main/java/amidst/mojangapi/world/WorldBuilder.java
+++ b/src/main/java/amidst/mojangapi/world/WorldBuilder.java
@@ -1,7 +1,6 @@
 package amidst.mojangapi.world;
 
 import java.io.IOException;
-import java.util.function.Consumer;
 
 import amidst.documentation.Immutable;
 import amidst.mojangapi.file.ImmutablePlayerInformationProvider;
@@ -49,24 +48,21 @@ public class WorldBuilder {
 
 	public World from(
 			MinecraftInterface minecraftInterface,
-			Consumer<World> onDisposeWorld, // TODO: remove this, it shouldn't be necessary anymore
 			WorldOptions worldOptions) throws MinecraftInterfaceException {
 		VersionFeatures versionFeatures = initInterfaceAndGetFeatures(worldOptions, minecraftInterface);
 		return create(
 				minecraftInterface.getRecognisedVersion(),
-				onDisposeWorld,
 				MovablePlayerList.dummy(),
 				versionFeatures,
 				versionFeatures.get(FeatureKey.WORLD_SPAWN_ORACLE));
 	}
 
-	public World fromSaveGame(MinecraftInterface minecraftInterface, Consumer<World> onDisposeWorld, SaveGame saveGame)
+	public World fromSaveGame(MinecraftInterface minecraftInterface, SaveGame saveGame)
 			throws IOException,
 			MinecraftInterfaceException {
 		VersionFeatures versionFeatures = initInterfaceAndGetFeatures(WorldOptions.fromSaveGame(saveGame), minecraftInterface);
 		return create(
 				minecraftInterface.getRecognisedVersion(),
-				onDisposeWorld,
 				new MovablePlayerList(
 					playerInformationProvider,
 					saveGame,
@@ -89,13 +85,11 @@ public class WorldBuilder {
 
 	private World create(
 			RecognisedVersion recognisedVersion,
-			Consumer<World> onDisposeWorld,
 			MovablePlayerList movablePlayerList,
 			VersionFeatures versionFeatures,
 			WorldSpawnOracle worldSpawnOracle) throws MinecraftInterfaceException {
 
 		return new World(
-				onDisposeWorld,
 				versionFeatures.get(FeatureKey.WORLD_OPTIONS),
 				movablePlayerList,
 				recognisedVersion,

--- a/src/main/java/amidst/mojangapi/world/WorldBuilder.java
+++ b/src/main/java/amidst/mojangapi/world/WorldBuilder.java
@@ -49,7 +49,7 @@ public class WorldBuilder {
 
 	public World from(
 			MinecraftInterface minecraftInterface,
-			Consumer<World> onDisposeWorld,
+			Consumer<World> onDisposeWorld, // TODO: remove this, it shouldn't be necessary anymore
 			WorldOptions worldOptions) throws MinecraftInterfaceException {
 		VersionFeatures versionFeatures = initInterfaceAndGetFeatures(worldOptions, minecraftInterface);
 		return create(
@@ -79,12 +79,12 @@ public class WorldBuilder {
 	private VersionFeatures initInterfaceAndGetFeatures(WorldOptions worldOptions, MinecraftInterface minecraftInterface)
 		throws MinecraftInterfaceException {
 		RecognisedVersion recognisedVersion = minecraftInterface.getRecognisedVersion();
-		minecraftInterface.createWorld(
+		MinecraftInterface.World minecraftWorld = minecraftInterface.createWorld(
 			worldOptions.getWorldSeed().getLong(),
 			worldOptions.getWorldType(),
 			worldOptions.getGeneratorOptions());
 		seedHistoryLogger.log(recognisedVersion, worldOptions.getWorldSeed());
-		return DefaultVersionFeatures.builder(worldOptions, minecraftInterface).create(recognisedVersion);
+		return DefaultVersionFeatures.builder(worldOptions, minecraftWorld).create(recognisedVersion);
 	}
 
 	private World create(

--- a/src/main/java/amidst/mojangapi/world/WorldSeed.java
+++ b/src/main/java/amidst/mojangapi/world/WorldSeed.java
@@ -1,6 +1,5 @@
 package amidst.mojangapi.world;
 
-import java.nio.ByteBuffer;
 import java.security.SecureRandom;
 
 import amidst.documentation.Immutable;

--- a/src/main/java/amidst/mojangapi/world/oracle/BiomeDataOracle.java
+++ b/src/main/java/amidst/mojangapi/world/oracle/BiomeDataOracle.java
@@ -17,11 +17,13 @@ import amidst.mojangapi.world.coordinates.Resolution;
 
 @ThreadSafe
 public class BiomeDataOracle {
-	private final MinecraftInterface minecraftInterface;
+	private final MinecraftInterface.World minecraftWorld;
+	private final RecognisedVersion recognisedVersion;
 	private final BiomeList biomeList;
 
-	public BiomeDataOracle(MinecraftInterface minecraftInterface, BiomeList biomeList) {
-		this.minecraftInterface = minecraftInterface;
+	public BiomeDataOracle(MinecraftInterface.World minecraftWorld, RecognisedVersion recognisedVersion, BiomeList biomeList) {
+		this.minecraftWorld = minecraftWorld;
+		this.recognisedVersion = recognisedVersion;
 		this.biomeList = biomeList;
 	}
 
@@ -111,7 +113,7 @@ public class BiomeDataOracle {
 	}
 
 	public CoordinatesInWorld findValidLocation(int x, int y, int size, List<Biome> validBiomes, Random random) {
-		if(RecognisedVersion.isNewerOrEqualTo(minecraftInterface.getRecognisedVersion(), RecognisedVersion._18w06a)) {
+		if(RecognisedVersion.isNewerOrEqualTo(recognisedVersion, RecognisedVersion._18w06a)) {
 			return doFindValidLocation(x, y, size, validBiomes, random, true);
 		} else {
 			return doFindValidLocation(x, y, size, validBiomes, random, false);
@@ -197,6 +199,6 @@ public class BiomeDataOracle {
 
 	private int[] getBiomeData(int x, int y, int width, int height, boolean useQuarterResolution)
 			throws MinecraftInterfaceException {
-		return minecraftInterface.getBiomeData(x, y, width, height, useQuarterResolution);
+		return minecraftWorld.getBiomeData(x, y, width, height, useQuarterResolution);
 	}
 }

--- a/src/main/java/amidst/mojangapi/world/oracle/BiomeDataOracle.java
+++ b/src/main/java/amidst/mojangapi/world/oracle/BiomeDataOracle.java
@@ -2,6 +2,7 @@ package amidst.mojangapi.world.oracle;
 
 import java.util.List;
 import java.util.Random;
+import java.util.function.Function;
 
 import amidst.documentation.ThreadSafe;
 import amidst.logging.AmidstLogger;
@@ -35,7 +36,10 @@ public class BiomeDataOracle {
 			int left = (int) corner.getXAs(resolution);
 			int top = (int) corner.getYAs(resolution);
 			try {
-				copyToResult(result, width, height, getBiomeData(left, top, width, height, useQuarterResolution));
+				minecraftWorld.getBiomeData(left, top, width, height, useQuarterResolution, biomeData -> {
+					copyToResult(result, width, height, biomeData);
+					return null;
+				});
 			} catch (MinecraftInterfaceException e) {
 				AmidstLogger.error(e);
 				AmidstMessageBox.displayError("Error", e);
@@ -84,18 +88,17 @@ public class BiomeDataOracle {
 		int bottom = y + size >> 2;
 		int width = right - left + 1;
 		int height = bottom - top + 1;
+		int[] validBiomesIdx = getBiomeIndices(validBiomes);
 		try {
-			int[] biomeData = getQuarterResolutionBiomeData(left, top, width, height);
-			for (int i = 0; i < width * height; i++) {
-				if (!validBiomes.contains(biomeList.getById(biomeData[i]))) {
-					return false;
+			return getQuarterResolutionBiomeData(left, top, width, height, biomeData -> {
+				for (int i = 0; i < width * height; i++) {
+					if (!containsInt(validBiomesIdx, biomeData[i])) {
+						return false;
+					}
 				}
-			}
-			return true;
-		} catch (UnknownBiomeIdException e) {
-			AmidstLogger.error(e);
-			AmidstMessageBox.displayError("Error", e);
-			return false;
+
+				return true;
+			});
 		} catch (MinecraftInterfaceException e) {
 			AmidstLogger.error(e);
 			AmidstMessageBox.displayError("Error", e);
@@ -132,25 +135,24 @@ public class BiomeDataOracle {
 		int bottom = y + size >> 2;
 		int width = right - left + 1;
 		int height = bottom - top + 1;
+		int[] validBiomesIdx = getBiomeIndices(validBiomes);
 		try {
-			int[] biomeData = getQuarterResolutionBiomeData(left, top, width, height);
-			CoordinatesInWorld result = null;
-			int numberOfValidLocations = 0;
-			for (int i = 0; i < width * height; i++) {
-				if(validBiomes.contains(biomeList.getById(biomeData[i]))) {
-					boolean updateResult = result == null || random.nextInt(numberOfValidLocations + 1) == 0;
-					result = updateResult ? createCoordinates(left, top, width, i) : result;
+			return getQuarterResolutionBiomeData(left, top, width, height, biomeData -> {
+				CoordinatesInWorld result = null;
+				int numberOfValidLocations = 0;
+				for (int i = 0; i < width * height; i++) {
+					if (containsInt(validBiomesIdx, biomeData[i])) {
+						boolean updateResult = result == null || random.nextInt(numberOfValidLocations + 1) == 0;
+						result = updateResult ? createCoordinates(left, top, width, i) : result;
 
-					if(accurateLocationCount || updateResult) {
-						numberOfValidLocations++;
+						if(accurateLocationCount || updateResult) {
+							numberOfValidLocations++;
+						}
+						break;
 					}
 				}
-			}
-			return result;
-		} catch (UnknownBiomeIdException e) {
-			AmidstLogger.error(e);
-			AmidstMessageBox.displayError("Error", e);
-			return null;
+				return result;
+			});
 		} catch (MinecraftInterfaceException e) {
 			AmidstLogger.error(e);
 			AmidstMessageBox.displayError("Error", e);
@@ -173,32 +175,43 @@ public class BiomeDataOracle {
 			MinecraftInterfaceException {
 		return getBiomeAt(getMiddleOfChunk(chunkX), getMiddleOfChunk(chunkY));
 	}
-	
-	public int getBiomeAt(int x, int y, boolean useQuarterResolution) throws UnknownBiomeIdException, MinecraftInterfaceException {
-		return getBiomeData(x, y, 1, 1, useQuarterResolution)[0];
+
+	public int getBiomeAt(int x, int y, boolean useQuarterResolution)
+			throws UnknownBiomeIdException, MinecraftInterfaceException {
+		return minecraftWorld.getBiomeData(x, y, 1, 1, useQuarterResolution, data -> data[0]);
 	}
 
+	private static int[] getBiomeIndices(List<Biome> biomes) {
+		return biomes.stream()
+			.mapToInt(Biome::getId)
+			.toArray();
+	}
+
+	private static boolean containsInt(int[] haystack, int needle) {
+		for (int elem: haystack) {
+			if (elem == needle) {
+				return true;
+			}
+		}
+		return false;
+	}
 	/**
 	 * Gets the biome located at the block-coordinates. This is not a fast
 	 * routine, it was added for rare things like accurately testing structures.
 	 * (uses the 1:1 scale biome-map)
 	 */
 	private Biome getBiomeAt(int x, int y) throws UnknownBiomeIdException, MinecraftInterfaceException {
-		int[] biomeData = getFullResolutionBiomeData(x, y, 1, 1);
-		return biomeList.getById(biomeData[0]);
+		int biomeIndex = getFullResolutionBiomeData(x, y, 1, 1, biomeData -> biomeData[0]);
+		return biomeList.getById(biomeIndex);
 	}
 
-	private int[] getQuarterResolutionBiomeData(int x, int y, int width, int height)
+	private<T> T getQuarterResolutionBiomeData(int x, int y, int width, int height, Function<int[], T> biomeDataMapper)
 			throws MinecraftInterfaceException {
-		return getBiomeData(x, y, width, height, true);
+		return minecraftWorld.getBiomeData(x, y, width, height, true, biomeDataMapper);
 	}
 
-	private int[] getFullResolutionBiomeData(int x, int y, int width, int height) throws MinecraftInterfaceException {
-		return getBiomeData(x, y, width, height, false);
-	}
-
-	private int[] getBiomeData(int x, int y, int width, int height, boolean useQuarterResolution)
+	private<T> T getFullResolutionBiomeData(int x, int y, int width, int height, Function<int[], T> biomeDataMapper)
 			throws MinecraftInterfaceException {
-		return minecraftWorld.getBiomeData(x, y, width, height, useQuarterResolution);
+		return minecraftWorld.getBiomeData(x, y, width, height, false, biomeDataMapper);
 	}
 }

--- a/src/main/java/amidst/mojangapi/world/versionfeatures/DefaultVersionFeatures.java
+++ b/src/main/java/amidst/mojangapi/world/versionfeatures/DefaultVersionFeatures.java
@@ -38,18 +38,18 @@ import amidst.mojangapi.world.oracle.SlimeChunkOracle;
 public enum DefaultVersionFeatures {
 	;
 
-	public static VersionFeatures.Builder builder(WorldOptions worldOptions, MinecraftInterface minecraftInterface) {
-		if (worldOptions == null || minecraftInterface == null) {
+	public static VersionFeatures.Builder builder(WorldOptions worldOptions, MinecraftInterface.World minecraftWorld) {
+		if (worldOptions == null || minecraftWorld == null) {
 			return FEATURES_BUILDER.clone();
 		} else {
 			return FEATURES_BUILDER.clone()
 							.withValue(FeatureKey.WORLD_OPTIONS, worldOptions)
-							.withValue(MINECRAFT_INTERFACE, minecraftInterface);
+							.withValue(MINECRAFT_WORLD, minecraftWorld);
 		}
 	}
 
 	// @formatter:off
-	private static final FeatureKey<MinecraftInterface> MINECRAFT_INTERFACE                        = FeatureKey.make();
+	private static final FeatureKey<MinecraftInterface.World> MINECRAFT_WORLD                      = FeatureKey.make();
 	public static final FeatureKey<List<Biome>>    VALID_BIOMES_FOR_STRUCTURE_SPAWN                = FeatureKey.make();
 	private static final FeatureKey<List<Biome>>   VALID_BIOMES_AT_MIDDLE_OF_CHUNK_STRONGHOLD      = FeatureKey.make();
 	private static final FeatureKey<List<Biome>>   VALID_BIOMES_FOR_STRUCTURE_VILLAGE              = FeatureKey.make();
@@ -80,11 +80,10 @@ public enum DefaultVersionFeatures {
 	private static final FeatureKey<Boolean>       BUGGY_STRUCTURE_COORDINATE_MATH                 = FeatureKey.make();
 
 	private static final VersionFeatures.Builder FEATURES_BUILDER = VersionFeatures.builder()
-			.with(FeatureKey.BIOME_DATA_ORACLE, VersionFeature.bind(features ->
-				VersionFeature.constant(new BiomeDataOracle(
-					features.get(MINECRAFT_INTERFACE),
-					features.get(FeatureKey.BIOME_LIST)
-				))
+			.with(FeatureKey.BIOME_DATA_ORACLE, (recognisedVersion, features) -> new BiomeDataOracle(
+				features.get(MINECRAFT_WORLD),
+				recognisedVersion,
+				features.get(FeatureKey.BIOME_LIST)
 			))
 			.with(FeatureKey.ENABLED_LAYERS, VersionFeature.<Integer> listBuilder()
 				.init(

--- a/src/main/java/amidst/util/ArrayCache.java
+++ b/src/main/java/amidst/util/ArrayCache.java
@@ -1,38 +1,59 @@
 package amidst.util;
 
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Function;
 import java.util.function.IntFunction;
 import java.util.function.ToIntFunction;
 
-public class ArrayCache<T> {
+import amidst.documentation.ThreadSafe;
 
-	private final ThreadLocal<T> array;
-	private final IntFunction<T> constructor;
-	private final ToIntFunction<T> lengthGetter;
+@ThreadSafe
+public class ArrayCache<A> {
 
-	private ArrayCache(IntFunction<T> constructor, ToIntFunction<T> lengthGetter, int initialSize) {
+	private final ConcurrentLinkedQueue<A> arrays;
+	private final IntFunction<A> constructor;
+	private final ToIntFunction<A> lengthGetter;
+	private final int initialSize;
+
+	private ArrayCache(IntFunction<A> constructor, ToIntFunction<A> lengthGetter, int initialSize) {
+		this.arrays = new ConcurrentLinkedQueue<>();
 		this.constructor = constructor;
 		this.lengthGetter = lengthGetter;
-		this.array = new ThreadLocal<T>() {
-			@Override
-			protected T initialValue() {
-                return constructor.apply(initialSize);
-			}
-		};
+		this.initialSize = initialSize;
 	}
 
-	public T getArray(int minimalSize) {
-		T dataArray = array.get();
+	public<T, E extends Throwable> T withArrayFaillible(
+			int minimalSize,
+			FaillibleFunction<A, T, E> arrayMapper
+		) throws E {
+		int requiredSize = Math.max(initialSize, minimalSize);
+		A dataArray = arrays.poll();
 
-		int cur = lengthGetter.applyAsInt(dataArray);
-		if (minimalSize <= cur)
-			return dataArray;
+		if (dataArray == null) {
+			// No arrays available in queue: create a fresh one
+			dataArray = constructor.apply(requiredSize);
+		} else {
+			int cur = lengthGetter.applyAsInt(dataArray);
 
-		while (cur < minimalSize)
-			cur *= 2;
+			// Array is too small: create a larger one
+			if (cur < requiredSize) {
+				do {
+					cur = Math.max(1, cur*2);
+				} while (cur < requiredSize);
+				dataArray = constructor.apply(cur);
+			}
+		}
 
-		dataArray = constructor.apply(cur);
-		array.set(dataArray);
-		return dataArray;
+		try {
+			return arrayMapper.apply(dataArray);
+		} finally {
+			// We're done with this array, put it back in the queue
+			arrays.add(dataArray);
+		}
+	}
+
+	public<T> T withArray(int minimalSize, Function<A, T> arrayMapper) {
+		return this.withArrayFaillible(minimalSize, (FaillibleFunction<A, T, RuntimeException>) arrayMapper::apply);
 	}
 
 	public static ArrayCache<int[]> makeIntArrayCache(int initialSize) {

--- a/src/main/java/amidst/util/ArrayCache.java
+++ b/src/main/java/amidst/util/ArrayCache.java
@@ -1,0 +1,41 @@
+package amidst.util;
+
+import java.util.function.IntFunction;
+import java.util.function.ToIntFunction;
+
+public class ArrayCache<T> {
+
+	private final ThreadLocal<T> array;
+	private final IntFunction<T> constructor;
+	private final ToIntFunction<T> lengthGetter;
+
+	private ArrayCache(IntFunction<T> constructor, ToIntFunction<T> lengthGetter, int initialSize) {
+		this.constructor = constructor;
+		this.lengthGetter = lengthGetter;
+		this.array = new ThreadLocal<T>() {
+			@Override
+			protected T initialValue() {
+                return constructor.apply(initialSize);
+			}
+		};
+	}
+
+	public T getArray(int minimalSize) {
+		T dataArray = array.get();
+
+		int cur = lengthGetter.applyAsInt(dataArray);
+		if (minimalSize <= cur)
+			return dataArray;
+
+		while (cur < minimalSize)
+			cur *= 2;
+
+		dataArray = constructor.apply(cur);
+		array.set(dataArray);
+		return dataArray;
+	}
+
+	public static ArrayCache<int[]> makeIntArrayCache(int initialSize) {
+		return new ArrayCache<>(int[]::new, a -> a.length, initialSize);
+	}
+}

--- a/src/main/java/amidst/util/FaillibleFunction.java
+++ b/src/main/java/amidst/util/FaillibleFunction.java
@@ -1,0 +1,6 @@
+package amidst.util;
+
+@FunctionalInterface
+public interface FaillibleFunction<T, U, E extends Throwable> {
+	public U apply(T value) throws E;
+}

--- a/src/test/java/amidst/mojangapi/mocking/BenchmarkingMinecraftInterface.java
+++ b/src/test/java/amidst/mojangapi/mocking/BenchmarkingMinecraftInterface.java
@@ -2,6 +2,7 @@ package amidst.mojangapi.mocking;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 
 import amidst.documentation.ThreadSafe;
 import amidst.mojangapi.minecraftinterface.MinecraftInterface;
@@ -39,16 +40,16 @@ public class BenchmarkingMinecraftInterface implements MinecraftInterface {
 		}
 
 		@Override
-		public int[] getBiomeData(int x, int y, int width, int height, boolean useQuarterResolution)
-				throws MinecraftInterfaceException {
+		public<T> T getBiomeData(int x, int y, int width, int height,
+				boolean useQuarterResolution, Function<int[], T> biomeDataMapper) throws MinecraftInterfaceException {
 			long start = System.nanoTime();
-			int[] biomeData = innerWorld.getBiomeData(x, y, width, height, useQuarterResolution);
-			long end = System.nanoTime();
+			return innerWorld.getBiomeData(x, y, width, height, useQuarterResolution, biomeData -> {
+				long end = System.nanoTime();
+				String thread = Thread.currentThread().getName();
+				records.add(new BiomeRequestRecordJson(x, y, width, height, useQuarterResolution, start, end-start, thread));
 
-			String thread = Thread.currentThread().getName();
-			records.add(new BiomeRequestRecordJson(x, y, width, height, useQuarterResolution, start, end-start, thread));
-
-			return biomeData;
+				return biomeDataMapper.apply(biomeData);
+			});
 		}
 	}
 }

--- a/src/test/java/amidst/mojangapi/mocking/BenchmarkingMinecraftInterface.java
+++ b/src/test/java/amidst/mojangapi/mocking/BenchmarkingMinecraftInterface.java
@@ -21,26 +21,34 @@ public class BenchmarkingMinecraftInterface implements MinecraftInterface {
 	}
 
 	@Override
-	public int[] getBiomeData(int x, int y, int width, int height, boolean useQuarterResolution)
+	public MinecraftInterface.World createWorld(long seed, WorldType worldType, String generatorOptions)
 			throws MinecraftInterfaceException {
-		long start = System.nanoTime();
-		int[] biomeData = inner.getBiomeData(x, y, width, height, useQuarterResolution);
-		long end = System.nanoTime();
-		
-		String thread = Thread.currentThread().getName();
-		records.add(new BiomeRequestRecordJson(x, y, width, height, useQuarterResolution, start, end-start, thread));
-		
-		return biomeData;
-	}
-
-	@Override
-	public void createWorld(long seed, WorldType worldType, String generatorOptions)
-			throws MinecraftInterfaceException {
-		inner.createWorld(seed, worldType, generatorOptions);
+		return new World(inner.createWorld(seed, worldType, generatorOptions));
 	}
 
 	@Override
 	public RecognisedVersion getRecognisedVersion() {
 		return inner.getRecognisedVersion();
+	}
+
+	private class World implements MinecraftInterface.World {
+		private final MinecraftInterface.World innerWorld;
+
+		private World(MinecraftInterface.World innerWorld) {
+			this.innerWorld = innerWorld;
+		}
+
+		@Override
+		public int[] getBiomeData(int x, int y, int width, int height, boolean useQuarterResolution)
+				throws MinecraftInterfaceException {
+			long start = System.nanoTime();
+			int[] biomeData = innerWorld.getBiomeData(x, y, width, height, useQuarterResolution);
+			long end = System.nanoTime();
+
+			String thread = Thread.currentThread().getName();
+			records.add(new BiomeRequestRecordJson(x, y, width, height, useQuarterResolution, start, end-start, thread));
+
+			return biomeData;
+		}
 	}
 }

--- a/src/test/java/amidst/mojangapi/mocking/FakeMinecraftInterface.java
+++ b/src/test/java/amidst/mojangapi/mocking/FakeMinecraftInterface.java
@@ -13,7 +13,6 @@ public class FakeMinecraftInterface implements MinecraftInterface {
 	private final WorldMetadataJson worldMetadataJson;
 	private final BiomeDataJson quarterBiomeData;
 	private final BiomeDataJson fullBiomeData;
-	private volatile boolean isWorldCreated = false;
 
 	public FakeMinecraftInterface(
 			WorldMetadataJson worldMetadataJson,
@@ -25,31 +24,12 @@ public class FakeMinecraftInterface implements MinecraftInterface {
 	}
 
 	@Override
-	public int[] getBiomeData(int x, int y, int width, int height, boolean useQuarterResolution)
-			throws MinecraftInterfaceException {
-		if (isWorldCreated) {
-			return getBiomeData(useQuarterResolution).get(x, y, width, height);
-		} else {
-			throw new MinecraftInterfaceException("the world needs to be created first");
-		}
-	}
-
-	private BiomeDataJson getBiomeData(boolean useQuarterResolution) {
-		if (useQuarterResolution) {
-			return quarterBiomeData;
-		} else {
-			return fullBiomeData;
-		}
-	}
-
-	@Override
-	public void createWorld(long seed, WorldType worldType, String generatorOptions)
+	public MinecraftInterface.World createWorld(long seed, WorldType worldType, String generatorOptions)
 			throws MinecraftInterfaceException {
 		if (worldMetadataJson.getSeed() == seed && worldMetadataJson.getWorldType().equals(worldType)
 				&& generatorOptions.isEmpty()) {
-			isWorldCreated = true;
+			return new World();
 		} else {
-			isWorldCreated = false;
 			throw new MinecraftInterfaceException("the world has to match");
 		}
 	}
@@ -57,5 +37,17 @@ public class FakeMinecraftInterface implements MinecraftInterface {
 	@Override
 	public RecognisedVersion getRecognisedVersion() {
 		return worldMetadataJson.getRecognisedVersion();
+	}
+
+	private class World implements MinecraftInterface.World {
+		private World() {
+		}
+
+		@Override
+		public int[] getBiomeData(int x, int y, int width, int height, boolean useQuarterResolution)
+				throws MinecraftInterfaceException {
+			BiomeDataJson biomes = useQuarterResolution ? quarterBiomeData : fullBiomeData;
+			return biomes.get(x, y, width, height);
+		}
 	}
 }

--- a/src/test/java/amidst/mojangapi/mocking/FakeMinecraftInterface.java
+++ b/src/test/java/amidst/mojangapi/mocking/FakeMinecraftInterface.java
@@ -1,5 +1,7 @@
 package amidst.mojangapi.mocking;
 
+import java.util.function.Function;
+
 import amidst.documentation.ThreadSafe;
 import amidst.mojangapi.minecraftinterface.MinecraftInterface;
 import amidst.mojangapi.minecraftinterface.MinecraftInterfaceException;
@@ -44,10 +46,11 @@ public class FakeMinecraftInterface implements MinecraftInterface {
 		}
 
 		@Override
-		public int[] getBiomeData(int x, int y, int width, int height, boolean useQuarterResolution)
+		public<T> T getBiomeData(int x, int y, int width, int height,
+				boolean useQuarterResolution, Function<int[], T> biomeDataMapper)
 				throws MinecraftInterfaceException {
 			BiomeDataJson biomes = useQuarterResolution ? quarterBiomeData : fullBiomeData;
-			return biomes.get(x, y, width, height);
+			return biomeDataMapper.apply(biomes.get(x, y, width, height));
 		}
 	}
 }

--- a/src/test/java/amidst/mojangapi/mocking/FakeWorldBuilder.java
+++ b/src/test/java/amidst/mojangapi/mocking/FakeWorldBuilder.java
@@ -1,7 +1,6 @@
 package amidst.mojangapi.mocking;
 
 import java.util.Map;
-import java.util.function.Consumer;
 
 import amidst.documentation.ThreadSafe;
 import amidst.mojangapi.minecraftinterface.MinecraftInterface;
@@ -21,8 +20,6 @@ public class FakeWorldBuilder {
 		return new FakeWorldBuilder(WorldBuilder.createSilentPlayerless(), directoryDeclaration);
 	}
 
-	private static final Consumer<World> NOOP = disposedWorld -> {
-	};
 	private final WorldBuilder builder;
 	private final TestWorldDirectoryDeclaration directoryDeclaration;
 
@@ -35,7 +32,6 @@ public class FakeWorldBuilder {
 			throws MinecraftInterfaceException {
 		return builder.from(
 				realMinecraftInterface,
-				NOOP,
 				worldDeclaration.getWorldOptions());
 	}
 
@@ -59,7 +55,6 @@ public class FakeWorldBuilder {
 			BiomeDataJson fullBiomeData) throws MinecraftInterfaceException {
 		return builder.from(
 				createFakeMinecraftInterface(worldMetadata, quarterBiomeData, fullBiomeData),
-				NOOP,
 				worldMetadata.intoWorldOptions());
 	}
 

--- a/src/test/java/amidst/mojangapi/mocking/RequestStoringMinecraftInterface.java
+++ b/src/test/java/amidst/mojangapi/mocking/RequestStoringMinecraftInterface.java
@@ -16,26 +16,34 @@ public class RequestStoringMinecraftInterface implements MinecraftInterface {
 		this.builder = builder;
 	}
 
-	@Override
-	public synchronized int[] getBiomeData(int x, int y, int width, int height, boolean useQuarterResolution)
-			throws MinecraftInterfaceException {
-		int[] biomeData = realMinecraftInterface.getBiomeData(x, y, width, height, useQuarterResolution);
-		store(x, y, width, height, useQuarterResolution, biomeData);
-		return biomeData;
-	}
-
 	private void store(int x, int y, int width, int height, boolean useQuarterResolution, int[] biomeData) {
 		builder.store(x, y, width, height, useQuarterResolution, biomeData);
 	}
 
 	@Override
-	public synchronized void createWorld(long seed, WorldType worldType, String generatorOptions)
+	public synchronized MinecraftInterface.World createWorld(long seed, WorldType worldType, String generatorOptions)
 			throws MinecraftInterfaceException {
-		realMinecraftInterface.createWorld(seed, worldType, generatorOptions);
+		return new World(realMinecraftInterface.createWorld(seed, worldType, generatorOptions));
 	}
 
 	@Override
 	public synchronized RecognisedVersion getRecognisedVersion() {
 		return realMinecraftInterface.getRecognisedVersion();
+	}
+
+	private class World implements MinecraftInterface.World {
+		private final MinecraftInterface.World realMinecraftWorld;
+
+		private World(MinecraftInterface.World realMinecraftWorld) {
+			this.realMinecraftWorld = realMinecraftWorld;
+		}
+
+		@Override
+		public synchronized int[] getBiomeData(int x, int y, int width, int height, boolean useQuarterResolution)
+				throws MinecraftInterfaceException {
+			int[] biomeData = realMinecraftWorld.getBiomeData(x, y, width, height, useQuarterResolution);
+			store(x, y, width, height, useQuarterResolution, biomeData);
+			return biomeData;
+		}
 	}
 }

--- a/src/test/java/amidst/mojangapi/mocking/RequestStoringMinecraftInterface.java
+++ b/src/test/java/amidst/mojangapi/mocking/RequestStoringMinecraftInterface.java
@@ -1,5 +1,7 @@
 package amidst.mojangapi.mocking;
 
+import java.util.function.Function;
+
 import amidst.documentation.ThreadSafe;
 import amidst.mojangapi.minecraftinterface.MinecraftInterface;
 import amidst.mojangapi.minecraftinterface.MinecraftInterfaceException;
@@ -39,11 +41,13 @@ public class RequestStoringMinecraftInterface implements MinecraftInterface {
 		}
 
 		@Override
-		public synchronized int[] getBiomeData(int x, int y, int width, int height, boolean useQuarterResolution)
+		public synchronized<T> T getBiomeData(int x, int y, int width, int height,
+				boolean useQuarterResolution, Function<int[], T> biomeDataMapper)
 				throws MinecraftInterfaceException {
-			int[] biomeData = realMinecraftWorld.getBiomeData(x, y, width, height, useQuarterResolution);
-			store(x, y, width, height, useQuarterResolution, biomeData);
-			return biomeData;
+			return realMinecraftWorld.getBiomeData(x, y, width, height, useQuarterResolution, biomeData -> {
+				store(x, y, width, height, useQuarterResolution, biomeData);
+				return biomeDataMapper.apply(biomeData);
+			});
 		}
 	}
 }

--- a/src/test/java/amidst/mojangapi/world/test/VersionFeaturesTest.java
+++ b/src/test/java/amidst/mojangapi/world/test/VersionFeaturesTest.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 import org.junit.Test;
 
@@ -53,7 +54,8 @@ public class VersionFeaturesTest {
 
 	private static class MockMinecraftWorld implements MinecraftInterface.World {
 		@Override
-		public int[] getBiomeData(int x, int y, int width, int height, boolean useQuarterResolution) {
+		public<T> T getBiomeData(int x, int y, int width, int height, boolean useQuarterResolution,
+				Function<int[], T> biomeDataMapper) {
 			throw new UnsupportedOperationException();
 		}
 	}

--- a/src/test/java/amidst/mojangapi/world/test/VersionFeaturesTest.java
+++ b/src/test/java/amidst/mojangapi/world/test/VersionFeaturesTest.java
@@ -34,8 +34,8 @@ public class VersionFeaturesTest {
 
 	public VersionFeatures.Builder createVersionFeaturesBuilder() {
 		WorldOptions worldOptions = new WorldOptions(WorldSeed.fromSaveGame(0), WorldType.DEFAULT);
-		MinecraftInterface minecraftInterface = new MockMinecraftInterface();
-		return DefaultVersionFeatures.builder(worldOptions, minecraftInterface);
+		MinecraftInterface.World minecraftWorld = new MockMinecraftWorld();
+		return DefaultVersionFeatures.builder(worldOptions, minecraftWorld);
 	}
 
 	public List<FeatureKey<?>> getRequiredFeatures() throws IllegalAccessException {
@@ -51,19 +51,9 @@ public class VersionFeaturesTest {
 		return features;
 	}
 
-	private static class MockMinecraftInterface implements MinecraftInterface {
+	private static class MockMinecraftWorld implements MinecraftInterface.World {
 		@Override
 		public int[] getBiomeData(int x, int y, int width, int height, boolean useQuarterResolution) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void createWorld(long seed, WorldType worldType, String generatorOptions) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public RecognisedVersion getRecognisedVersion() {
 			throw new UnsupportedOperationException();
 		}
 	}


### PR DESCRIPTION
This refactors all `MinecraftInterface`s to allow creating multiple worlds at the same time with a single `MinecraftInterface` instance. As a consequence, the Amidst world disposing logic (via `World.dispose()`) isn't necessary anymore, and has been removed.

Additionally, it should now be possible to switch worlds while an export operation (see #716) is in process; I still need to do more testing to be sure that nothing breaks before making this change.