### PR TITLE
Retain biome selection between world switches

### DIFF
--- a/src/main/java/amidst/gui/main/Actions.java
+++ b/src/main/java/amidst/gui/main/Actions.java
@@ -81,7 +81,6 @@ public class Actions {
 
 	@CalledOnlyBy(AmidstThread.EDT)
 	public void newFromRandom() {
-		biomeExporterDialog.dispose();
 		newFromSeed(WorldSeed.random());
 	}
 

--- a/src/main/java/amidst/gui/main/viewer/widget/BiomeToggleWidget.java
+++ b/src/main/java/amidst/gui/main/viewer/widget/BiomeToggleWidget.java
@@ -11,20 +11,18 @@ import amidst.gui.main.viewer.BiomeSelection;
 
 @NotThreadSafe
 public class BiomeToggleWidget extends ImmutableIconWidget {
-	private final BiomeWidget biomeWidget;
 	private final BiomeSelection biomeSelection;
 
 	@CalledOnlyBy(AmidstThread.EDT)
-	public BiomeToggleWidget(CornerAnchorPoint anchor, BiomeWidget biomeWidget, BiomeSelection biomeSelection) {
+	public BiomeToggleWidget(CornerAnchorPoint anchor, BiomeSelection biomeSelection) {
 		super(anchor, ResourceLoader.getImage("/amidst/gui/main/highlighter.png"));
-		this.biomeWidget = biomeWidget;
 		this.biomeSelection = biomeSelection;
 	}
 
 	@CalledOnlyBy(AmidstThread.EDT)
 	@Override
 	public boolean onMousePressed(int x, int y) {
-		biomeWidget.toggleVisibility();
+		BiomeWidget.toggleVisibility();
 		return true;
 	}
 

--- a/src/main/java/amidst/gui/main/viewer/widget/BiomeWidget.java
+++ b/src/main/java/amidst/gui/main/viewer/widget/BiomeWidget.java
@@ -41,7 +41,7 @@ public class BiomeWidget extends Widget {
 	private int maxNameWidth = 0;
 	private int biomeListHeight;
 	private boolean isInitialized = false;
-	private boolean isVisible = false;
+	private static boolean isVisible = false;
 
 	private Rectangle innerBox = new Rectangle(0, 0, 1, 1);
 
@@ -72,7 +72,7 @@ public class BiomeWidget extends Widget {
 	}
 
 	@CalledOnlyBy(AmidstThread.EDT)
-	public void toggleVisibility() {
+	public static void toggleVisibility() {
 		isVisible = !isVisible;
 	}
 


### PR DESCRIPTION
Fixes #824. The biome selection widget may have been intended to reset when the world switches, but I'm not sure.