### PR TITLE
Fix integer overflow in end city icon generation

### DIFF
--- a/src/main/java/amidst/mojangapi/world/icon/type/EndCityWorldIconTypeProvider.java
+++ b/src/main/java/amidst/mojangapi/world/icon/type/EndCityWorldIconTypeProvider.java
@@ -17,7 +17,8 @@ public class EndCityWorldIconTypeProvider implements WorldIconTypeProvider<List<
 
 	@Override
 	public DefaultWorldIconTypes get(int chunkX, int chunkY, List<EndIsland> endIslands) {
-		if ((chunkX * chunkX + chunkY * chunkY) > 4096) {
+		// Convert coordinates to long to guard against overflow
+		if (((long) chunkX * (long) chunkX + (long) chunkY * (long) chunkY) > 4096) {
 			return hasSuitableIslandFoundation(chunkX, chunkY, endIslands);
 		} else {
 			return null;


### PR DESCRIPTION
Fixes #838.

Would likely make more sense to pass chunks along as a `long`, which was also mentioned in `StructureProducer`: https://github.com/toolbox4minecraft/amidst/blob/57444ba1268523102687e1e7b6b2057e39c1e3b5/src/main/java/amidst/mojangapi/world/icon/producer/StructureProducer.java#L53-L75

Perhaps that's a change worth making?