### PR TITLE
[feature] Better Nether Coords

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,5 +124,11 @@
 			<scope>provided</scope>
 			<type>maven-plugin</type>
 		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>RELEASE</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/src/main/java/amidst/gui/main/Actions.java
+++ b/src/main/java/amidst/gui/main/Actions.java
@@ -39,6 +39,10 @@ import amidst.settings.biomeprofile.BiomeProfile;
 import amidst.settings.biomeprofile.BiomeProfileDirectory;
 import amidst.settings.biomeprofile.BiomeProfileSelection;
 import amidst.util.FileExtensionChecker;
+import amidst.util.Pair;
+import jdk.jfr.BooleanFlag;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 
 @NotThreadSafe
 public class Actions {
@@ -136,9 +140,9 @@ public class Actions {
 	public void goToCoordinate() {
 		ViewerFacade viewerFacade = viewerFacadeSupplier.get();
 		if (viewerFacade != null) {
-			String input = dialogs.askForCoordinates();
-			if (input != null) {
-				CoordinatesInWorld coordinates = CoordinatesInWorld.tryParse(input);
+			Pair<String, Boolean> output = dialogs.askForCoordinates();
+			if (output.getFirst() != null) {
+				CoordinatesInWorld coordinates = CoordinatesInWorld.tryParse(output.getFirst(), output.getSecond());
 				if (coordinates != null) {
 					viewerFacade.centerOn(coordinates);
 				} else {
@@ -424,5 +428,4 @@ public class Actions {
 		}
 		return Paths.get(filename);
 	}
-
 }

--- a/src/main/java/amidst/gui/main/MainWindowDialogs.java
+++ b/src/main/java/amidst/gui/main/MainWindowDialogs.java
@@ -3,9 +3,7 @@ package amidst.gui.main;
 import java.nio.file.Path;
 import java.util.List;
 
-import javax.swing.JFileChooser;
-import javax.swing.JFrame;
-import javax.swing.JOptionPane;
+import javax.swing.*;
 
 import amidst.AmidstSettings;
 import amidst.documentation.AmidstThread;
@@ -16,6 +14,7 @@ import amidst.mojangapi.RunningLauncherProfile;
 import amidst.mojangapi.world.WorldSeed;
 import amidst.mojangapi.world.WorldType;
 import amidst.mojangapi.world.player.WorldPlayerType;
+import amidst.util.Pair;
 
 @NotThreadSafe
 public class MainWindowDialogs {
@@ -147,8 +146,12 @@ public class MainWindowDialogs {
 	}
 
 	@CalledOnlyBy(AmidstThread.EDT)
-	public String askForCoordinates() {
-		return askForString("Go To", "Enter coordinates: (Ex. 123,456)");
+	public Pair<String, Boolean> askForCoordinates() {
+		JCheckBox checkbox = new JCheckBox("Nether");
+		String message = "Enter coordinates: (Ex. 123,456)";
+		Object[] params = {message, checkbox};
+		String answer = JOptionPane.showInputDialog(frame, params, "Go To", JOptionPane.QUESTION_MESSAGE);
+		return Pair.of(answer, checkbox.isSelected());
 	}
 
 	@CalledOnlyBy(AmidstThread.EDT)

--- a/src/main/java/amidst/gui/main/MainWindowDialogs.java
+++ b/src/main/java/amidst/gui/main/MainWindowDialogs.java
@@ -170,10 +170,5 @@ public class MainWindowDialogs {
 			return null;
 		}
 	}
-
-	@CalledOnlyBy(AmidstThread.EDT)
-	private String askForString(String title, String message) {
-		return JOptionPane.showInputDialog(frame, message, title, JOptionPane.QUESTION_MESSAGE);
-	}
 	
 }

--- a/src/main/java/amidst/gui/main/viewer/widget/CursorInformationWidget.java
+++ b/src/main/java/amidst/gui/main/viewer/widget/CursorInformationWidget.java
@@ -49,7 +49,7 @@ public class CursorInformationWidget extends TextWidget {
 		if (mousePosition != null) {
 			CoordinatesInWorld coordinates = translator.screenToWorld(mousePosition);
 			String biomeName = getBiomeNameAt(coordinates);
-			return Arrays.asList(biomeName + " " + coordinates.toString());
+			return Arrays.asList(biomeName, "Overworld: " + coordinates.toString(), "Nether: " + CoordinatesInWorld.toNether(coordinates).toString());
 		} else {
 			return null;
 		}

--- a/src/main/java/amidst/mojangapi/world/coordinates/CoordinatesInWorld.java
+++ b/src/main/java/amidst/mojangapi/world/coordinates/CoordinatesInWorld.java
@@ -15,10 +15,10 @@ public class CoordinatesInWorld implements Comparable<CoordinatesInWorld> {
 			long x = Long.parseLong(parsedCoordinates[0]);
 			long z = Long.parseLong(parsedCoordinates[1]);
 			if (isNether) {
-				x *= 8;
-				z *= 8;
+				return CoordinatesInWorld.fromNether(x, z);
+			} else {
+				return CoordinatesInWorld.from(x, z);
 			}
-			return CoordinatesInWorld.from(x, z);
 		} catch (NumberFormatException e) {
 			return null;
 		}
@@ -26,6 +26,14 @@ public class CoordinatesInWorld implements Comparable<CoordinatesInWorld> {
 
 	public static CoordinatesInWorld from(long xInWorld, long yInWorld) {
 		return new CoordinatesInWorld(xInWorld, yInWorld);
+	}
+
+	public static CoordinatesInWorld fromNether(long xInWorld, long yInWorld) {
+		return new CoordinatesInWorld(xInWorld * 8, yInWorld * 8);
+	}
+
+	public static CoordinatesInWorld toNether(CoordinatesInWorld coordinates) {
+		return new CoordinatesInWorld(coordinates.xInWorld / 8, coordinates.yInWorld / 8);
 	}
 
 	public static CoordinatesInWorld from(long xAsResolution, long yAsResolution, Resolution resolution) {

--- a/src/main/java/amidst/mojangapi/world/coordinates/CoordinatesInWorld.java
+++ b/src/main/java/amidst/mojangapi/world/coordinates/CoordinatesInWorld.java
@@ -6,13 +6,19 @@ import amidst.documentation.Immutable;
 
 @Immutable
 public class CoordinatesInWorld implements Comparable<CoordinatesInWorld> {
-	public static CoordinatesInWorld tryParse(String coordinates) {
+	public static CoordinatesInWorld tryParse(String coordinates, Boolean isNether) {
 		String[] parsedCoordinates = coordinates.replaceAll(" ", "").split(",");
 		if (parsedCoordinates.length != 2) {
 			return null;
 		}
 		try {
-			return CoordinatesInWorld.from(Long.parseLong(parsedCoordinates[0]), Long.parseLong(parsedCoordinates[1]));
+			long x = Long.parseLong(parsedCoordinates[0]);
+			long z = Long.parseLong(parsedCoordinates[1]);
+			if (isNether) {
+				x *= 8;
+				z *= 8;
+			}
+			return CoordinatesInWorld.from(x, z);
 		} catch (NumberFormatException e) {
 			return null;
 		}

--- a/src/main/java/amidst/util/Pair.java
+++ b/src/main/java/amidst/util/Pair.java
@@ -1,0 +1,11 @@
+package amidst.util;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor(staticName = "of")
+public class Pair<F, S> {
+    private F first;
+    private S second;
+}


### PR DESCRIPTION
Those simple changes actually improve the usablilty of this tool for anachy servers by a lot. It's way easier to handle huge coords when using nether as origin. Also when searching from nether for specific biomes its always good to know both coords in widget.

Note: The Pair class is really practical and i bet its may can get used later on too. If you dont want it just remove it and do the unpractical way.

<img src="https://cdn.discordapp.com/attachments/805473348351819827/818292983190781963/unknown.png" width="60%"/>
<img src="https://cdn.discordapp.com/attachments/805473348351819827/818311095139434516/unknown.png" width="20%"/>