### PR TITLE
Update JDK version from 1.8 to 1.16

### DIFF
--- a/src/main/resources/amidst/metadata.properties
+++ b/src/main/resources/amidst/metadata.properties
@@ -1,8 +1,8 @@
 project.build.sourceEncoding=UTF-8
-amidst.build.jdk.version=1.8
+amidst.build.jdk.version=1.16
 amidst.build.filename=amidst-v4-7
 
 amidst.version.major=4
 amidst.version.minor=7
-amidst.version.patch=0
+amidst.version.patch=1
 amidst.version.preReleaseSuffix=


### PR DESCRIPTION
This is the fix required to make the executable work. 
I couldn't figure out how to use Travis-CI because I'm not the most intelligent person ever, so I can't compile it for everyone else, but here's the fix for the 40 some issues that have been created for 1.17.