### PR TITLE
Update JDK version from 1.8 to 17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-- openjdk8
+- openjdk17
 addons:
   apt:
     packages:

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.2.4</version>
+				<version>3.3.0-SNAPSHOT</version>
 				<executions>
 					<execution>
 						<phase>package</phase>
@@ -125,4 +125,10 @@
 			<type>maven-plugin</type>
 		</dependency>
 	</dependencies>
+	<pluginRepositories>
+		<pluginRepository>
+			<id>maven-snapshots</id>
+			<url>https://repository.apache.org/content/repositories/snapshots/</url>
+		</pluginRepository>
+	</pluginRepositories>
 </project>

--- a/src/main/resources/amidst/metadata.properties
+++ b/src/main/resources/amidst/metadata.properties
@@ -1,8 +1,8 @@
 project.build.sourceEncoding=UTF-8
-amidst.build.jdk.version=1.8
+amidst.build.jdk.version=1.16
 amidst.build.filename=amidst-v4-7
 
 amidst.version.major=4
 amidst.version.minor=7
-amidst.version.patch=0
+amidst.version.patch=1
 amidst.version.preReleaseSuffix=

--- a/src/main/resources/amidst/metadata.properties
+++ b/src/main/resources/amidst/metadata.properties
@@ -1,8 +1,8 @@
 project.build.sourceEncoding=UTF-8
-amidst.build.jdk.version=1.16
-amidst.build.filename=amidst-v4-7
+amidst.build.jdk.version=17
+amidst.build.filename=amidst-v4-7-java17
 
 amidst.version.major=4
 amidst.version.minor=7
-amidst.version.patch=1
+amidst.version.patch=0
 amidst.version.preReleaseSuffix=

--- a/travis-ci/wrapper-for-windows/pom.xml
+++ b/travis-ci/wrapper-for-windows/pom.xml
@@ -28,7 +28,7 @@
 			<plugin>
 				<groupId>com.akathist.maven.plugins.launch4j</groupId>
 				<artifactId>launch4j-maven-plugin</artifactId>
-				<version>1.7.8</version>
+				<version>2.1.1</version>
 				<executions>
 					<execution>
 						<id>launch4j</id>


### PR DESCRIPTION
Supersedes #1020 (thanks @Mobmaker55 for making a start with this! :slightly_smiling_face:)

This PR updates the build configuration to use Java 17. This makes Amidst work for Minecraft 1.17 and below.
In Minecraft 1.18, world generation has had a large overhaul, and I am not planning to make an attempt to update Amidst to work with this (I have experience with Java, but not with Minecraft internals, unfortunately).

For anyone who wants to use the Java 17 version of Amidst v4.7, I have published the binaries here: https://github.com/mpsijm/amidst/releases/tag/v4.7-java-17